### PR TITLE
Export Uniform and UniformRange

### DIFF
--- a/System/Random.hs
+++ b/System/Random.hs
@@ -76,6 +76,8 @@ module System.Random
   , newStdGen
 
   -- * Random values of various types
+  , Uniform(..)
+  , UniformRange(..)
   , Random(..)
 
   -- * Generators for sequences of bytes


### PR DESCRIPTION
Follow-up to https://github.com/idontgetoutmuch/random/pull/14. I assume this was just forgotten ... or do we not want to export `Uniform` and `UniformRange`?