### PR TITLE
Add 'initialize' function

### DIFF
--- a/System/Random.hs
+++ b/System/Random.hs
@@ -111,6 +111,7 @@ import Foreign.Ptr (plusPtr)
 import Foreign.Storable (peekByteOff, pokeByteOff)
 import GHC.ForeignPtr
 
+import Data.Binary.Get (Get, getWord64le)
 import Data.IORef (IORef, newIORef, readIORef, writeIORef, atomicModifyIORef')
 import System.IO.Unsafe (unsafePerformIO)
 import qualified System.Random.SplitMix as SM
@@ -130,6 +131,9 @@ mutableByteArrayContentsCompat = mutableByteArrayContents
 -- generators.
 --
 class RandomGen g where
+  -- | Initialize this instance from a seed.
+  initialize :: Get g
+
   -- |The 'next' operation returns an 'Int' that is uniformly distributed
   -- in the range returned by 'genRange' (including both end points),
   -- and a new generator.
@@ -331,6 +335,10 @@ runStateTGen_ g = fmap fst . flip runStateT g
 type StdGen = SM.SMGen
 
 instance RandomGen StdGen where
+  initialize = do
+    i <- getWord64le
+    j <- getWord64le
+    return $ SM.seedSMGen i j
   next = SM.nextInt
   genWord32 = SM.nextWord32
   genWord64 = SM.nextWord64

--- a/random.cabal
+++ b/random.cabal
@@ -31,6 +31,7 @@ Library
         System.Random
     ghc-options: -Wall
     build-depends: base >= 3 && < 5
+                 , binary
                  , bytestring
                  , primitive
                  , mtl


### PR DESCRIPTION
Generic initialisation of PRNGs. This makes it possible to implement something like C++ `seed_seq` or numpy `SeedSequence` as a library.

Code extracted from https://github.com/idontgetoutmuch/random/pull/12.