### PR TITLE
[WIP] Use bitmaskWithRejection

### DIFF
--- a/System/Random.hs
+++ b/System/Random.hs
@@ -120,7 +120,7 @@
 -- >>> :{
 -- let rolls :: [Word32]
 --     rolls = runGenState_
---               (PCGen 17 29)
+--               (PCGen' 17 29)
 --               (randomListM PureGen 10 >>= \xs -> return $ map ((+1) . (`mod` 6)) xs)
 -- :}
 --

--- a/System/Random.hs
+++ b/System/Random.hs
@@ -296,10 +296,10 @@ class RandomGen g where
   genWord64 = genWord64R maxBound
 
   genWord32R :: Word32 -> g -> (Word32, g)
-  genWord32R m = randomIvalIntegral (minBound, m)
+  genWord32R m = bitmaskWithRejection (minBound, m)
 
   genWord64R :: Word64 -> g -> (Word64, g)
-  genWord64R m = randomIvalIntegral (minBound, m)
+  genWord64R m = bitmaskWithRejection (minBound, m)
 
   genByteArray :: Int -> g -> (ByteArray, g)
   genByteArray n g = runPureGenST g $ uniformByteArrayPrim n
@@ -999,38 +999,13 @@ randomFloat rng =
 --   -- random rng = case random rng of
 --   --                  (x,rng') -> (realToFrac (x::Double), rng')
 
--- The two integer functions below take an [inclusive,inclusive] range.
-randomIvalIntegral :: (RandomGen g, Integral a) => (a, a) -> g -> (a, g)
-randomIvalIntegral (l,h) = randomIvalInteger (toInteger l, toInteger h)
-
-{-# SPECIALIZE randomIvalInteger :: (Num a) =>
-    (Integer, Integer) -> StdGen -> (a, StdGen) #-}
-
-randomIvalInteger :: (RandomGen g, Num a) => (Integer, Integer) -> g -> (a, g)
-randomIvalInteger (l,h) rng
- | l > h     = randomIvalInteger (h,l) rng
- | otherwise = case (f 1 0 rng) of (v, rng') -> (fromInteger (l + v `mod` k), rng')
-     where
-       (genlo, genhi) = genRange rng
-       b = fromIntegral genhi - fromIntegral genlo + 1
-
-       -- Probabilities of the most likely and least likely result
-       -- will differ at most by a factor of (1 +- 1/q).  Assuming the RandomGen
-       -- is uniform, of course
-
-       -- On average, log q / log b more random values will be generated
-       -- than the minimum
-       q = 1000
-       k = h - l + 1
-       magtgt = k * q
-
-       -- generate random values until we exceed the target magnitude
-       f mag v g | mag >= magtgt = (v, g)
-                 | otherwise = v' `seq`f (mag*b) v' g' where
-                        (x,g') = next g
-                        v' = (v * b + (fromIntegral x - fromIntegral genlo))
-
-
+-- | Generate a random number in an inclusive range.
+--
+-- The order of arguments does not matter:
+-- > bitmaskWithRejection a b == bitmaskWithRejection b a
+--
+-- The range is inclusive. Assuming a <= b, we have:
+-- > a <= bitmaskWithRejection a b <= b
 bitmaskWithRejection ::
      (RandomGen g, FiniteBits a, Num a, Ord a, Random a)
   => (a, a)
@@ -1046,7 +1021,7 @@ bitmaskWithRejection (bottom, top)
     go g =
       let (x, g') = random g
           x' = x .&. mask
-       in if x' >= range
+       in if x' > range
             then go g'
             else (x', g')
 {-# INLINE bitmaskWithRejection #-}
@@ -1068,7 +1043,7 @@ bitmaskWithRejectionRM (bottom, top) gen
     go = do
       x <- randomM gen
       let x' = x .&. mask
-      if x' >= range
+      if x' > range
         then go
         else pure x'
 {-# INLINE bitmaskWithRejectionRM #-}
@@ -1080,7 +1055,7 @@ bitmaskWithRejectionM genUniform range gen = go
     go = do
       x <- genUniform gen
       let x' = x .&. mask
-      if x' >= range
+      if x' > range
         then go
         else pure x'
 


### PR DESCRIPTION
... and make it and its cousins inclusive in the top end of the range.

Todo:
- [ ] Ensure this works with RNGs that only define `next`