### PR TITLE
Add a few initial specs

### DIFF
--- a/System/Random.hs
+++ b/System/Random.hs
@@ -90,6 +90,8 @@ module System.Random
   -- * References
   -- $references
 
+  -- * Internals
+  , bitmaskWithRejection -- FIXME Export this in a better way, e.g. in System.Random.Impl or something like that
   ) where
 
 import Prelude

--- a/random.cabal
+++ b/random.cabal
@@ -46,3 +46,18 @@ test-suite legacy
         base -any,
         random -any,
         containers -any
+
+test-suite spec
+    type:           exitcode-stdio-1.0
+    main-is:        Spec.hs
+    hs-source-dirs: tests
+    other-modules:
+        Spec.Bitmask
+        Spec.Range
+
+    ghc-options:    -Wall
+    build-depends:
+        base -any,
+        random -any,
+        tasty -any,
+        tasty-smallcheck -any

--- a/random.cabal
+++ b/random.cabal
@@ -60,4 +60,5 @@ test-suite spec
         base -any,
         random -any,
         tasty -any,
-        tasty-smallcheck -any
+        tasty-smallcheck -any,
+        tasty-expected-failure -any

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,6 @@
+resolver: lts-15.2
+packages:
+  - .
+flags:
+  splitmix:
+    random: False

--- a/tests/Spec.hs
+++ b/tests/Spec.hs
@@ -2,12 +2,14 @@
 
 module Main (main) where
 
+import Data.Word (Word32, Word64)
+import System.Random
+import Test.Tasty
+import Test.Tasty.ExpectedFailure (expectFail)
+import Test.Tasty.SmallCheck as SC
+
 import qualified Spec.Bitmask as Bitmask
 import qualified Spec.Bitmask as Range
-import System.Random
-import Data.Word (Word32, Word64)
-import Test.Tasty
-import Test.Tasty.SmallCheck as SC
 
 main :: IO ()
 main = defaultMain $ testGroup "Spec"
@@ -39,8 +41,7 @@ rangeSpecWord32 = testGroup "uniformR (Word32)"
 rangeSpecInt :: TestTree
 rangeSpecInt = testGroup "uniformR (Int)"
     [ SC.testProperty "(Int) symmetric" $ seeded $ Range.symmetric @StdGen @Int
-    -- FIXME Make this pass
-    -- , SC.testProperty "(Int) bounded" $ seeded $ Range.bounded @StdGen @Int
+    , expectFail $ SC.testProperty "(Int) bounded" $ seeded $ Range.bounded @StdGen @Int
     , SC.testProperty "(Int) singleton" $ seeded $ Range.singleton @StdGen @Int
     ]
 

--- a/tests/Spec.hs
+++ b/tests/Spec.hs
@@ -1,0 +1,49 @@
+{-# LANGUAGE TypeApplications #-}
+
+module Main (main) where
+
+import qualified Spec.Bitmask as Bitmask
+import qualified Spec.Bitmask as Range
+import System.Random
+import Data.Word (Word32, Word64)
+import Test.Tasty
+import Test.Tasty.SmallCheck as SC
+
+main :: IO ()
+main = defaultMain $ testGroup "Spec"
+    [ bitmaskSpecWord32, bitmaskSpecWord64
+    , rangeSpecWord32, rangeSpecInt
+    ]
+
+bitmaskSpecWord32 :: TestTree
+bitmaskSpecWord32 = testGroup "bitmaskWithRejection (Word32)"
+    [ SC.testProperty "symmetric" $ seeded $ Bitmask.symmetric @StdGen @Word32
+    , SC.testProperty "bounded" $ seeded $ Bitmask.bounded @StdGen @Word32
+    , SC.testProperty "singleton" $ seeded $ Bitmask.singleton @StdGen @Word32
+    ]
+
+bitmaskSpecWord64 :: TestTree
+bitmaskSpecWord64 = testGroup "bitmaskWithRejection (Word64)"
+    [ SC.testProperty "symmetric" $ seeded $ Bitmask.symmetric @StdGen @Word64
+    , SC.testProperty "bounded" $ seeded $ Bitmask.bounded @StdGen @Word64
+    , SC.testProperty "singleton" $ seeded $ Bitmask.singleton @StdGen @Word64
+    ]
+
+rangeSpecWord32 :: TestTree
+rangeSpecWord32 = testGroup "uniformR (Word32)"
+    [ SC.testProperty "(Word32) symmetric" $ seeded $ Range.symmetric @StdGen @Word32
+    , SC.testProperty "(Word32) bounded" $ seeded $ Range.bounded @StdGen @Word32
+    , SC.testProperty "(Word32) singleton" $ seeded $ Range.singleton @StdGen @Word32
+    ]
+
+rangeSpecInt :: TestTree
+rangeSpecInt = testGroup "uniformR (Int)"
+    [ SC.testProperty "(Int) symmetric" $ seeded $ Range.symmetric @StdGen @Int
+    -- FIXME Make this pass
+    -- , SC.testProperty "(Int) bounded" $ seeded $ Range.bounded @StdGen @Int
+    , SC.testProperty "(Int) singleton" $ seeded $ Range.singleton @StdGen @Int
+    ]
+
+-- | Create a StdGen instance from an Int and pass it to the given function.
+seeded :: (StdGen -> a) -> Int -> a
+seeded f = f . mkStdGen

--- a/tests/Spec/Bitmask.hs
+++ b/tests/Spec/Bitmask.hs
@@ -1,0 +1,19 @@
+module Spec.Bitmask (symmetric, bounded, singleton) where
+
+import Data.Bits
+import System.Random
+
+symmetric :: (RandomGen g, FiniteBits a, Num a, Ord a, Random a) => g -> (a, a) -> Bool
+symmetric g (l, r) = fst (bitmaskWithRejection (l, r) g) == fst (bitmaskWithRejection (r, l) g)
+
+bounded :: (RandomGen g, FiniteBits a, Num a, Ord a, Random a) => g -> (a, a) -> Bool
+bounded g (l, r) = bottom <= result && result <= top
+  where
+    bottom = min l r
+    top = max l r
+    result = fst (bitmaskWithRejection (l, r) g)
+
+singleton :: (RandomGen g, FiniteBits a, Num a, Ord a, Random a) => g -> a -> Bool
+singleton g x = result == x
+  where
+    result = fst (bitmaskWithRejection (x, x) g)

--- a/tests/Spec/Range.hs
+++ b/tests/Spec/Range.hs
@@ -1,0 +1,19 @@
+module Spec.Range (symmetric, bounded, singleton) where
+
+import Data.Bits
+import System.Random
+
+symmetric :: (RandomGen g, Random a, Eq a) => g -> (a, a) -> Bool
+symmetric g (l, r) = fst (randomR (l, r) g) == fst (randomR (r, l) g)
+
+bounded :: (RandomGen g, Random a, Ord a) => g -> (a, a) -> Bool
+bounded g (l, r) = bottom <= result && result <= top
+  where
+    bottom = min l r
+    top = max l r
+    result = fst (randomR (l, r) g)
+
+singleton :: (RandomGen g, Random a, Eq a) => g -> a -> Bool
+singleton g x = result == x
+  where
+    result = fst (randomR (x, x) g)


### PR DESCRIPTION
This PR adds a few initial specs, tested with SmallCheck + Tasty (a rare combination of testing frameworks that does not rely on `random` itself).

Although this is just a start, it already shows that `randomR` on `Int` is incorrect as it is implemented right now. I'm not fixing the implementation in this PR though: this is meant to be a starting point for more extensive tests, so I'm just committing the tests for now.

Merge after https://github.com/idontgetoutmuch/random/pull/30.