### PR TITLE
Pin splitmix-0.0.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -97,21 +97,21 @@ jobs:
   #  compiler: ": #stack 7.10.3"
   #  addons: {apt: {packages: [libgmp-dev]}}
 
-  #- env: BUILD=stack ARGS="--resolver lts-7"
-  #  compiler: ": #stack 8.0.1"
-  #  addons: {apt: {packages: [libgmp-dev]}}
+  - env: BUILD=stack ARGS="--resolver lts-7"
+    compiler: ": #stack 8.0.1"
+    addons: {apt: {packages: [libgmp-dev]}}
 
-  #- env: BUILD=stack ARGS="--resolver lts-9"
-  #  compiler: ": #stack 8.0.2"
-  #  addons: {apt: {packages: [libgmp-dev]}}
+  - env: BUILD=stack ARGS="--resolver lts-9"
+    compiler: ": #stack 8.0.2"
+    addons: {apt: {packages: [libgmp-dev]}}
 
-  #- env: BUILD=stack ARGS="--resolver lts-11"
-  #  compiler: ": #stack 8.2.2"
-  #  addons: {apt: {packages: [libgmp-dev]}}
+  - env: BUILD=stack ARGS="--resolver lts-11"
+    compiler: ": #stack 8.2.2"
+    addons: {apt: {packages: [libgmp-dev]}}
 
-  #- env: BUILD=stack ARGS="--resolver lts-12"
-  #  compiler: ": #stack 8.4.4"
-  #  addons: {apt: {packages: [libgmp-dev]}}
+  - env: BUILD=stack ARGS="--resolver lts-12"
+    compiler: ": #stack 8.4.4"
+    addons: {apt: {packages: [libgmp-dev]}}
 
   - env: BUILD=stack ARGS="--resolver lts-14"
     compiler: ": #stack 8.6.5"

--- a/.travis.yml
+++ b/.travis.yml
@@ -97,21 +97,21 @@ jobs:
   #  compiler: ": #stack 7.10.3"
   #  addons: {apt: {packages: [libgmp-dev]}}
 
-  - env: BUILD=stack ARGS="--resolver lts-7"
-    compiler: ": #stack 8.0.1"
-    addons: {apt: {packages: [libgmp-dev]}}
+  #- env: BUILD=stack ARGS="--resolver lts-7"
+  #  compiler: ": #stack 8.0.1"
+  #  addons: {apt: {packages: [libgmp-dev]}}
 
-  - env: BUILD=stack ARGS="--resolver lts-9"
-    compiler: ": #stack 8.0.2"
-    addons: {apt: {packages: [libgmp-dev]}}
+  #- env: BUILD=stack ARGS="--resolver lts-9"
+  #  compiler: ": #stack 8.0.2"
+  #  addons: {apt: {packages: [libgmp-dev]}}
 
   - env: BUILD=stack ARGS="--resolver lts-11"
     compiler: ": #stack 8.2.2"
     addons: {apt: {packages: [libgmp-dev]}}
 
-  - env: BUILD=stack ARGS="--resolver lts-12"
-    compiler: ": #stack 8.4.4"
-    addons: {apt: {packages: [libgmp-dev]}}
+  #- env: BUILD=stack ARGS="--resolver lts-12"
+  #  compiler: ": #stack 8.4.4"
+  #  addons: {apt: {packages: [libgmp-dev]}}
 
   - env: BUILD=stack ARGS="--resolver lts-14"
     compiler: ": #stack 8.6.5"

--- a/System/Random.hs
+++ b/System/Random.hs
@@ -213,7 +213,12 @@ import Data.Int
 import Data.IORef (IORef, atomicModifyIORef', newIORef, readIORef, writeIORef)
 import Data.Primitive.ByteArray
 import Data.Primitive.MutVar
+#if MIN_VERSION_primitive(0,6,4)
 import Data.Primitive.Types as Primitive (Prim, sizeOf)
+#else
+import qualified Data.Primitive as Primitive (sizeOf)
+import Data.Primitive.Types (Prim)
+#endif
 import Data.Word
 import Foreign.C.Types
 import Foreign.Marshal.Alloc (alloca)

--- a/stack.yaml
+++ b/stack.yaml
@@ -47,6 +47,8 @@ extra-deps:
   # >= 0.0.3 by default, this stack.yaml is also used in CI, where the resolver
   # is overridden, making this explicit pinning of splitmix necessary.
 - splitmix-0.0.4@sha256:fb9bb8b54a2e76c8a021fe5c4c3798047e1f60e168379a1f80693047fe00ad0e,4813
+  # Not contained in all snapshots we want to test against
+- cabal-doctest-1.0.8@sha256:34dff6369d417df2699af4e15f06bc181d495eca9c51efde173deae2053c197c,1491
 
 # Override default flag values for local packages and extra-deps
 flags:

--- a/stack.yaml
+++ b/stack.yaml
@@ -30,16 +30,23 @@ resolver: lts-15.1
 #   - wai
 packages:
 - .
+
 # Dependency packages to be pulled from upstream that are not in the resolver.
 # These entries can reference officially published versions as well as
 # forks / in-progress versions pinned to a git hash. For example:
-#
-# extra-deps:
-# - acme-missiles-0.3
-# - git: https://github.com/commercialhaskell/stack.git
-#   commit: e7b331f14bcffb8367cd58fbfc8b40ec7642100a
-#
-# extra-deps: []
+extra-deps:
+  # We require a splitmix version that supports the "random" flag. When this
+  # flag is set to false, splitmix does not depend on the random package. We
+  # require the flag to be set to false to avoid a circular dependency:
+  #     random -> splitmix -> random.
+  # The oldest splitmix version to support the "random" flag is 0.0.3. LTS
+  # snapshots prior to lts-14 contain older versions of splitmix. To make sure
+  # the build goes through, we pin the splitmix version here.
+  #
+  # Note that although the resolver defined in this file comes with a splitmix
+  # >= 0.0.3 by default, this stack.yaml is also used in CI, where the resolver
+  # is overridden, making this explicit pinning of splitmix necessary.
+- splitmix-0.0.4@sha256:fb9bb8b54a2e76c8a021fe5c4c3798047e1f60e168379a1f80693047fe00ad0e,4813
 
 # Override default flag values for local packages and extra-deps
 flags:

--- a/stack.yaml
+++ b/stack.yaml
@@ -49,6 +49,7 @@ extra-deps:
 - splitmix-0.0.4@sha256:fb9bb8b54a2e76c8a021fe5c4c3798047e1f60e168379a1f80693047fe00ad0e,4813
   # Not contained in all snapshots we want to test against
 - cabal-doctest-1.0.8@sha256:34dff6369d417df2699af4e15f06bc181d495eca9c51efde173deae2053c197c,1491
+- doctest-0.16.2@sha256:2f96e9bbe9aee11b47453c82c24b3dc76cdbb8a2a7c984dfd60b4906d08adf68,6942
 
 # Override default flag values for local packages and extra-deps
 flags:


### PR DESCRIPTION
Please see the explanation in `stack.yaml`.

Allows us to enable CI on lts-11.