### PR TITLE
I think I messed up the naming of PrimGen and MutGen

### DIFF
--- a/tests/Spec/Run.hs
+++ b/tests/Spec/Run.hs
@@ -8,5 +8,5 @@ import System.Random
 runsEqual :: RandomGen g => g -> IO Bool
 runsEqual g = do
     let (pureResult :: Word64) = runGenState_ g uniform
-    (genResult :: Word64) <- runPrimGenIO_ g uniform
+    (genResult :: Word64) <- runMutGenIO_ g uniform
     return $ pureResult == genResult


### PR DESCRIPTION
I think I really messed up the naming of `MutGen` and `PrimGen`, to the point that it confused me looking at the code after some time.

Although both of them can be operated in a `PrimMonad`, so "Prim" could just as well be applied to either one of them, but currently `MutGen`, requires `Prim` instance, while `PrimGen` is based on `MutVar` and does not require `Prim` instance. That part can be really confusing, so I propose to swap their names and that is exactly what this PR implements.