### PR TITLE
WIP: Prim gen to pvar

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -101,9 +101,9 @@ jobs:
   #   compiler: ": #stack 8.0.1"
   #   addons: {apt: {packages: [libgmp-dev]}}
 
-  # - env: BUILD=stack ARGS="--resolver lts-9"
-  #   compiler: ": #stack 8.0.2"
-  #   addons: {apt: {packages: [libgmp-dev]}}
+  - env: BUILD=stack ARGS="--resolver lts-9.21 --stack-yaml stack-old.yaml"
+    compiler: ": #stack 8.0.2"
+    addons: {apt: {packages: [libgmp-dev]}}
 
   - env: BUILD=stack ARGS="--resolver lts-11.22 --stack-yaml stack-old.yaml"
     compiler: ": #stack 8.2.2"

--- a/.travis.yml
+++ b/.travis.yml
@@ -97,9 +97,9 @@ jobs:
   #  compiler: ": #stack 7.10.3"
   #  addons: {apt: {packages: [libgmp-dev]}}
 
-  # - env: BUILD=stack ARGS="--resolver lts-7"
-  #   compiler: ": #stack 8.0.1"
-  #   addons: {apt: {packages: [libgmp-dev]}}
+  - env: BUILD=stack ARGS="--resolver lts-7.24 --stack-yaml stack-old.yaml"
+    compiler: ": #stack 8.0.1"
+    addons: {apt: {packages: [libgmp-dev]}}
 
   - env: BUILD=stack ARGS="--resolver lts-9.21 --stack-yaml stack-old.yaml"
     compiler: ": #stack 8.0.2"

--- a/System/Random.hs
+++ b/System/Random.hs
@@ -68,6 +68,7 @@
 -- >>> fst $ stepGen $ snd $ stepGen (PCGen 17 29)
 -- 3288430965
 --
+-- >>> import System.Random
 -- >>> :{
 -- instance RandomGen PCGen where
 --   next g = (fromIntegral y, h)

--- a/random.cabal
+++ b/random.cabal
@@ -32,9 +32,10 @@ library
     default-language: Haskell2010
     ghc-options:      -Wall
     build-depends:
-        base >=4.10 && <5,
+        base >=4.8 && <5,
         bytestring -any,
-        primitive >= 0.6.4.0 && <8,
+        primitive >= 0.5.4.0 && <8,
+        pvar -any,
         mtl -any,
         splitmix -any
     c-sources: cbits/CastFloatWord.cmm

--- a/stack-coveralls.yaml
+++ b/stack-coveralls.yaml
@@ -1,7 +1,8 @@
 resolver: lts-14.27
 packages:
 - .
-extra-deps: []
+extra-deps:
+- pvar-0.1.1.0@sha256:4715f603c0e87dbccdd49e1958554f8771f7730c8a61561552690b929223aa8f,1798
 flags:
   splitmix:
     random: false

--- a/stack-old.yaml
+++ b/stack-old.yaml
@@ -50,7 +50,7 @@ extra-deps:
   # Not contained in all snapshots we want to test against
 - doctest-0.16.2@sha256:2f96e9bbe9aee11b47453c82c24b3dc76cdbb8a2a7c984dfd60b4906d08adf68,6942
 - cabal-doctest-1.0.8@sha256:34dff6369d417df2699af4e15f06bc181d495eca9c51efde173deae2053c197c,1491
-- primitive-0.6.4.0@sha256:5b6a2c3cc70a35aabd4565fcb9bb1dd78fe2814a36e62428a9a1aae8c32441a1,2079
+- pvar-0.1.1.0@sha256:4715f603c0e87dbccdd49e1958554f8771f7730c8a61561552690b929223aa8f,1798
 
 # Override default flag values for local packages and extra-deps
 flags:

--- a/stack-old.yaml
+++ b/stack-old.yaml
@@ -51,6 +51,7 @@ extra-deps:
 - doctest-0.16.2@sha256:2f96e9bbe9aee11b47453c82c24b3dc76cdbb8a2a7c984dfd60b4906d08adf68,6942
 - cabal-doctest-1.0.8@sha256:34dff6369d417df2699af4e15f06bc181d495eca9c51efde173deae2053c197c,1491
 - pvar-0.1.1.0@sha256:4715f603c0e87dbccdd49e1958554f8771f7730c8a61561552690b929223aa8f,1798
+- smallcheck-1.1.5@sha256:e0d5c1d6241a734695d3808a3224fbf5f6640e86ca9d06031060eb209aaa10fe,1229
 
 # Override default flag values for local packages and extra-deps
 flags:

--- a/stack.yaml
+++ b/stack.yaml
@@ -34,7 +34,8 @@ packages:
 # Dependency packages to be pulled from upstream that are not in the resolver.
 # These entries can reference officially published versions as well as
 # forks / in-progress versions pinned to a git hash. For example:
-extra-deps: []
+extra-deps:
+- pvar-0.1.1.0@sha256:4715f603c0e87dbccdd49e1958554f8771f7730c8a61561552690b929223aa8f,1798
 
 # Override default flag values for local packages and extra-deps
 flags:


### PR DESCRIPTION
That PR is a bit more controversial, so I'd be totally ok with closing it. 

Nevertheless, it does brings some improvements and I'd certainly love to hear some feedback. Here is what it does:

While working on this mutable generator stored in a `MutableByteArrray#` I thought to myself that it would be nice to have a library with an interface like that, so I wrote and released [`pvar`](https://github.com/lehins/pvar) that does just that.

There are two perks of switching to `pvar` library, we get an interface that is slightly reacher, cause it is possible to use full functionality of `pvar` API with `PrimGen`.

Also we gain backwards compatibility with ghc-8.0 (and even all the way to ghc-7-10 that would mean lts-3 would be the last we could support as opposed to lts-12 right now) This is possible because I implemented some of the core functions in the library that are only available in ghc-8.2 and up, which we rely on in `random`

Depends on #57 