### PR TITLE
Make bitmaskWithRejectionM inclusive in the upper bound

### DIFF
--- a/System/Random.hs
+++ b/System/Random.hs
@@ -93,7 +93,7 @@
 -- :}
 --
 -- >>> rolls 20
--- [1,1,5,3,3,3,2,4,3,2,3,3,4,5,1,1,5,1,2,4]
+-- [1,1,5,3,6,3,3,2,4,3,2,3,3,4,6,6,5,6,1,1]
 --
 -- FIXME: What should we say about generating values from types other
 -- than Word8 etc?
@@ -1122,7 +1122,7 @@ bitmaskWithRejectionM genUniform range gen = go
     go = do
       x <- genUniform gen
       let x' = x .&. mask
-      if x' >= range
+      if x' > range
         then go
         else pure x'
 {-# INLINE bitmaskWithRejectionM #-}

--- a/tests/Spec.hs
+++ b/tests/Spec.hs
@@ -62,8 +62,6 @@ main =
     , integralSpec @CIntMax
     , integralSpec @CUIntMax
     , integralSpec @Integer
-    , rangeSpec @Char
-    , rangeSpec @Bool
     -- , bitmaskSpec @Word8
     -- , bitmaskSpec @Word16
     -- , bitmaskSpec @Word32


### PR DESCRIPTION
... as the `UniformRange` documentation says.

Builds on top of https://github.com/idontgetoutmuch/random/pull/58. I suggest we just merge this PR into `instances-and-warnings` to make this part of #58.