### PR TITLE
More efficient ranges for Word32

### DIFF
--- a/System/Random.hs
+++ b/System/Random.hs
@@ -1090,20 +1090,22 @@ uniformIntegerM (l, h) gen
         let v' = v * b + fromIntegral x
         v' `seq` f (mag * b) v'
 
--- | A slightly modified version of what can be found in [Lemire's
--- paper](https://arxiv.org/pdf/1805.10941.pdf), [O'Neill's
--- blogpost](https://www.pcg-random.org/posts/bounded-rands.html) and
--- more directly from [O'Neill's github
--- repo](https://github.com/imneme/bounded-rands/blob/3d71f53c975b1e5b29f2f3b05a74e26dab9c3d84/bounded32.cpp#L234).
--- The modification is we want the range to be [0,t] not [0,t) to be
--- compatible with unsignedBitmaskWithRejectionRM.
+-- | Uniformly generate Word32 in @[0, s]@.
 unbiasedWordMult32 :: MonadRandom g m => Word32 -> g -> m Word32
 unbiasedWordMult32 s g
   | s == maxBound = uniformWord32 g
-  | otherwise = go
+  | otherwise = unbiasedWordMult32Exclusive (s+1) g
+{-# INLINE unbiasedWordMult32 #-}
+
+-- | See [Lemire's paper](https://arxiv.org/pdf/1805.10941.pdf),
+-- [O'Neill's
+-- blogpost](https://www.pcg-random.org/posts/bounded-rands.html) and
+-- more directly [O'Neill's github
+-- repo](https://github.com/imneme/bounded-rands/blob/3d71f53c975b1e5b29f2f3b05a74e26dab9c3d84/bounded32.cpp#L234).
+-- N.B. The range is [0,t) **not** [0,t].
+unbiasedWordMult32Exclusive  :: MonadRandom g m => Word32 -> g -> m Word32
+unbiasedWordMult32Exclusive r g = go
   where
-    r :: Word32
-    r = s + 1
     t :: Word32
     t = (-r) `mod` r -- Calculates 2^32 `mod` r!!!
     go = do

--- a/System/Random.hs
+++ b/System/Random.hs
@@ -789,8 +789,7 @@ instance Uniform Word32 where
   uniform  = uniformWord32
 instance UniformRange Word32 where
   {-# INLINE uniformR #-}
-  uniformR (b, t) g | b == t    = pure b
-                    | b > t     = unbiasedIntMult32 (b - t) g >>= return . (+t)
+  uniformR (b, t) g | b > t     = unbiasedIntMult32 (b - t) g >>= return . (+t)
                     | otherwise = unbiasedIntMult32 (t - b) g >>= return . (+b)
 
 instance Random Word64 where
@@ -1093,7 +1092,7 @@ uniformIntegerM (l, h) gen
 
 unbiasedIntMult32 :: MonadRandom g m => Word32 -> g -> m Word32
 unbiasedIntMult32 s g
-  | s == 0    = pure 0
+  | s == maxBound = uniformWord32 g
   | otherwise = go
   where
     r :: Word32


### PR DESCRIPTION
This can now be merged (subject to review of course).  I don't think a drop in coverage of 0.1% is serious. Of course we should write more tests but in separate PRs.