### PR TITLE
Flip Frozen and Mutable types in MoandRandom

### DIFF
--- a/System/Random.hs
+++ b/System/Random.hs
@@ -117,7 +117,7 @@ module System.Random
 
   -- * Stateful interface for pure generators
   -- ** Based on StateT
-  , PureGen
+  , PureGen(..)
   , splitGen
   , genRandom
   , runGenState
@@ -127,7 +127,7 @@ module System.Random
   , runPureGenST
   -- ** Based on PrimMonad
   -- *** MutGen - boxed thread safe state
-  , MutGen
+  , MutGen(..)
   , runMutGenST
   , runMutGenST_
   , runMutGenIO
@@ -135,7 +135,7 @@ module System.Random
   , splitMutGen
   , atomicMutGen
   -- *** PrimGen - unboxed mutable state
-  , PrimGen
+  , PrimGen(..)
   , runPrimGenST
   , runPrimGenST_
   , runPrimGenIO

--- a/System/Random.hs
+++ b/System/Random.hs
@@ -432,11 +432,10 @@ runGenState g f = runState (f StateGenM) g
 runGenState_ :: RandomGen g => g -> (GenM (State g) (PureGen g) -> State g a) -> a
 runGenState_ g = fst . runGenState g
 
-runGenStateT :: RandomGen g => g -> (GenM (StateT g m) (PureGen g) -> StateT g m a) -> m (a, g)
+runGenStateT :: (RandomGen g, m ~ StateT g f) => g -> (GenM m (PureGen g) -> m a) -> f (a, g)
 runGenStateT g f = runStateT (f StateGenM) g
 
-runGenStateT_ :: (RandomGen g, Functor f) =>
-  g -> (GenM (StateT g f) (PureGen g) -> StateT g f a) -> f a
+runGenStateT_ :: (RandomGen g, Functor f, m ~ StateT g f) => g -> (GenM m (PureGen g) -> m a) -> f a
 runGenStateT_ g = fmap fst . runGenStateT g
 
 -- | This is a wrapper wround pure generator that can be used in an effectful environment.


### PR DESCRIPTION
This PR inverses the concept of Frozen/Mutable as far as `MoandRandom` is concerned. This is an implementation of @Shimuuar suggestion:
> Also I think it would be desirable to flip Frozen data family. Instead of mutable generator and its frozen state we should have frozen generator and its mutable version. 

Going this route does bring some benefits to the table.

### Here are the benefits that I can see:
* `PureGen`, `PrimGen`  and `MutGen` are now mere newtype wrappers around the actual pure RNG. They are now used for creating an instance. The problem it solves is that they are now properly exported and unlike before nice Haddock is being generated for constructors
* It might be easier for some to grasp this approach rather that the inverse. Pretty subjective argument
* Solves the issue of `Frozen` depending on the state token, which @Shimuuar grew to really hate ;) 
* some type signatures are easier: eg.
```haskell
withGenM :: MonadRandom g m => g -> (GenM m g -> m a) -> m (a, g)
-- vs 
withGenM :: MonadRandom g m => Frozen g -> (g -> m a) -> m (a, Frozen g)
```

### But it does have some drawbacks:
* Some signatures become slightly harder:
```haskell
runGenStateT :: RandomGen g => 
  g -> (GenM (StateT g m) (PureGen g) -> StateT g m a) -> m (a, g)
-- vs
runGenStateT :: RandomGen g => 
  g -> (PureGen g -> StateT g m a) -> m (a, g)
```
which could be slightly improved with type level equality constraint:
```haskell
runGenStateT :: (RandomGen g, n ~ StateT g m) => 
  g -> (GenM n (PureGen g) -> n a) -> m (a, g)
runGenStateT g f = runStateT (f StateGenM) g
```
* Another drawback affects stateful generators like one in `mwc-random`. The `Gen s` will have to be wrapped in a `newtype` (which might be not be a big deal at all):

So instead of:
```haskell
instance (s ~ PrimState m, PrimMonad m) => MonadRandom (Gen s) m where
  newtype Frozen (Gen s) = Frozen { unFrozen :: Seed }
  thawGen (Frozen seed) = restore seed
  freezeGen = fmap Frozen . save
```
we now will get:
```haskell
instance PrimMonad m => MonadRandom Seed m where
  newtype GenM m Seed = GenMWC (Gen (PrimState m))
  thawGen seed = GenMWC <$> restore seed
  freezeGen (GenMWC gen) = save gen
```

Both current and proposed solutions are very much equivalent in functionality. The fact that there was no change to tests and doctests shows how similar they actually are. The biggest change is the introduction of `GenM` data family that depends on the monad it is being used in, which, for better or worse, changes the type signatures of all monadic functions.

@Shimuuar, @idontgetoutmuch @curiousleo thoughts?