### PR TITLE
Faster 'uniform' and 'uniformR' for Bool

### DIFF
--- a/System/Random.hs
+++ b/System/Random.hs
@@ -970,16 +970,12 @@ instance UniformRange Char where
 instance Random Bool where
   randomM = uniform
 instance Uniform Bool where
-  uniform = uniformR (minBound, maxBound)
+  uniform = fmap wordToBool . uniformWord8
+    where wordToBool w = (w .&. 1) /= 0
 instance UniformRange Bool where
-  uniformR (a, b) g = int2Bool <$> uniformR (bool2Int a, bool2Int b) g
-    where
-      bool2Int :: Bool -> Int
-      bool2Int False = 0
-      bool2Int True  = 1
-      int2Bool :: Int -> Bool
-      int2Bool 0 = False
-      int2Bool _ = True
+  uniformR (False, False) _g = return False
+  uniformR (True, True)   _g = return True
+  uniformR _               g = uniform g
 
 instance Random Double where
   randomR r g = runGenState g (uniformR r)


### PR DESCRIPTION
Benchmark:

```
How many random numbers can we generate in a second on one thread?
  First, timing System.Random.next:                             BEFORE                 AFTER
  Second, timing System.Random.random at different types:
      1,859,311 randoms generated [System.Random Bools]       ~ 932 cycles/int       ~ 22.32 cycles/int
  Next timing range-restricted System.Random.randomR:
      1,608,582 randoms generated [System.Random Bools]       ~ 1,077 cycles/int     ~ 22.46 cycles/int
Now 8 threads, reporting mean randoms-per-second-per-thread:
  First, timing System.Random.next:
  Second, timing System.Random.random at different types:
        726,606 randoms generated [System.Random Bools]       ~ 2,385 cycles/int     ~ 43.49 cycles/int
  Next timing range-restricted System.Random.randomR:
        687,065 randoms generated [System.Random Bools]       ~ 2,523 cycles/int     ~ 46.32 cycles/int
```