### PR TITLE
Addition of state token to MonadRandom

### DIFF
--- a/System/Random.hs
+++ b/System/Random.hs
@@ -518,7 +518,7 @@ class RandomGen g where
   -- generators.
   split :: g -> (g, g)
 
-class Monad m => MonadRandom (g :: * -> *) s m | m -> s where
+class Monad m => MonadRandom g s m | m -> s where
   data Frozen g :: *
   {-# MINIMAL freezeGen,thawGen,(uniformWord32|uniformWord64) #-}
 


### PR DESCRIPTION
@Shimuuar I think I found a simple and elegant solution to our Frozen conundrum. Very similar to what you did in #71 except using fun deps. 

Instance form MWC becomes really nice:
```haskell
instance (s ~ PrimState m, PrimMonad m) => Random.MonadRandom Gen s m where
  newtype Frozen Gen = Frozen { unFrozen :: Seed }
  thawGen (Frozen seed) = restore seed
```

This approach adds very clutter around. It makes slightly uglier for `PureGen` and other instances that don't care about a state token (eg. IORef), but that's the price we'll have to pay for generality.

Let me know what you think.