### PR TITLE
Fix functional dependency conflict

### DIFF
--- a/System/Random.hs
+++ b/System/Random.hs
@@ -531,7 +531,7 @@ class RandomGen g where
   split :: g -> (g, g)
 
 -- | 'MonadRandom' is an interface to monadic pseudo-random number generators.
-class Monad m => MonadRandom g s m | m -> s where
+class Monad m => MonadRandom g s m | g m -> s where
   -- | Represents the state of the pseudo-random number generator for use with
   -- 'thawGen' and 'freezeGen'.
   --


### PR DESCRIPTION
m -> s functional dependency is too weak (it ws brought up in #79) and _does_ cause conflicts when
different generators have different nodes in the same monad. For example
adding following instance (as of 8215fd932292701a3eca0030451746978ca129d0)
```
> data G1 s = G1 (IORef Int)
>
> instance MonadRandom G1 () IO where
>   newtype Frozen G1 = F1 Int
```
causes error
```
> System/Random.hs:826:10: error:
>     Functional dependencies conflict between instance declarations:
>       instance (RandomGen g, MonadIO m) =>
>                MonadRandom (AtomicGen g) RealWorld m
>         -- Defined at System/Random.hs:826:10
>       instance (RandomGen g, MonadIO m) =>
>                MonadRandom (IOGen g) RealWorld m
>         -- Defined at System/Random.hs:878:10
>       instance MonadRandom G1 () IO
>         -- Defined at System/Random.hs:1733:10
```
Fix is very simple however: replace `m -> s` by `g m -> s` which makes perfect
sense, as state token type is determined by both g _and_ m.