### PR TITLE
Handle compilation warnings in legacy test suite

### DIFF
--- a/random.cabal
+++ b/random.cabal
@@ -50,7 +50,7 @@ test-suite legacy
         Legacy.RangeTest
 
     default-language: Haskell2010
-    ghc-options:      -with-rtsopts=-M4M
+    ghc-options:      -with-rtsopts=-M4M -Wno-deprecations
     build-depends:
         base -any,
         containers -any,

--- a/tests/Legacy/Random1283.hs
+++ b/tests/Legacy/Random1283.hs
@@ -1,21 +1,25 @@
 module Legacy.Random1283 (main) where
 
 import Control.Concurrent
-import Control.Monad hiding (empty)
-import Data.Sequence (ViewL(..), empty, fromList, viewl, (<|), (|>), (><))
+import Control.Monad
+import Data.Sequence (Seq, ViewL(..), empty, fromList, viewl, (<|), (|>), (><))
 import System.Random
 
 -- This test
 
+threads, samples :: Int
 threads = 4
 samples = 5000
 
+main :: IO ()
 main = loopTest threads samples
 
+loopTest :: Int -> Int -> IO ()
 loopTest t s = do
   isClean <- testRace t s
-  when (not isClean) $ putStrLn "race condition!"
+  unless isClean $ putStrLn "race condition!"
 
+testRace :: Int -> Int -> IO Bool
 testRace t s = do
   ref <- liftM (take (t*s) . randoms) getStdGen
   iss <- threadRandoms t s
@@ -25,11 +29,12 @@ threadRandoms :: Random a => Int -> Int -> IO [[a]]
 threadRandoms t s = do
   vs <- sequence $ replicate t $ do
     v <- newEmptyMVar
-    forkIO (sequence (replicate s randomIO) >>= putMVar v)
+    _ <- forkIO (sequence (replicate s randomIO) >>= putMVar v)
     return v
   mapM takeMVar vs
 
-isInterleavingOf xs yss = iio xs (viewl $ fromList yss) EmptyL where
+isInterleavingOf :: Eq a => [a] -> [[a]] -> Bool
+isInterleavingOf xs' yss' = iio xs' (viewl $ fromList yss') EmptyL where
   iio (x:xs) ((y:ys) :< yss) zss
     | x /= y = iio (x:xs) (viewl yss) (viewl (fromViewL zss |> (y:ys)))
     | x == y = iio xs (viewl ((ys <| yss) >< fromViewL zss)) EmptyL
@@ -37,6 +42,7 @@ isInterleavingOf xs yss = iio xs (viewl $ fromList yss) EmptyL where
   iio [] EmptyL EmptyL = True
   iio _ _ _ = False
 
-fromViewL (EmptyL) = empty
+fromViewL :: ViewL a -> Seq a
+fromViewL EmptyL = empty
 fromViewL (x :< xs) = x <| xs
 

--- a/tests/Legacy/RangeTest.hs
+++ b/tests/Legacy/RangeTest.hs
@@ -6,23 +6,23 @@ import Control.Monad
 import System.Random
 import Data.Int
 import Data.Word
-import Data.Bits
 import Foreign.C.Types
 
 -- Take many measurements and record the max/min/average random values.
-approxBounds :: (RandomGen g, Random a, Ord a, Num a) => 
-		(g -> (a,g)) -> Int -> a -> (a,a) -> g -> ((a,a,a),g)
+approxBounds ::
+  (RandomGen g, Random a, Ord a, Num a) =>
+  (g -> (a,g)) -> Int -> a -> (a,a) -> g -> ((a,a,a),g)
 -- Here we do a little hack to essentiall pass in the type in the last argument:
-approxBounds nxt iters unused (explo,exphi) initrng = 
-   if False 
+approxBounds nxt iters unused (explo,exphi) initrng =
+   if False
    then ((unused,unused,unused),undefined)
 --   else loop initrng iters 100 (-100) 0 -- Oops, can't use minBound/maxBound here.
-   else loop initrng iters exphi explo 0 -- Oops, can't use minBound/maxBound here.
- where 
-  loop rng 0 mn mx sum = ((mn,mx,sum),rng)
-  loop rng  n mn mx sum = 
-    case nxt rng of 
-      (x, rng') -> loop rng' (n-1) (min x mn) (max x mx) (x+sum)
+   else loop initrng iters exphi explo 0
+ where
+  loop rng 0 mn mx sum' = ((mn,mx,sum'),rng)
+  loop rng  n mn mx sum' =
+    case nxt rng of
+      (x, rng') -> loop rng' (n-1) (min x mn) (max x mx) (x+sum')
 
 
 -- We check that:
@@ -30,34 +30,34 @@ approxBounds nxt iters unused (explo,exphi) initrng =
 --     (2) we get "close" to the bounds
 -- The with (2) is that we do enough trials to ensure that we can at
 -- least hit the 90% mark.
-checkBounds:: (Real a, Show a, Ord a) =>
-	      String -> (Bool, a, a) -> ((a,a) -> StdGen -> ((a, a, t), StdGen)) -> IO ()
-checkBounds msg (exclusive,lo,hi) fun = 
- -- (lo,hi) is [inclusive,exclusive) 
- do putStr$ msg 
---	    ++ ", expected range " ++ show (lo,hi) 
-	    ++ ":  "
-    (mn,mx,sum) <- getStdRandom (fun (lo,hi))
-    when (mn <  lo)$ error$ "broke lower bound: " ++ show mn
-    when (mx > hi) $ error$ "broke upper bound: " ++ show mx
-    when (exclusive && mx >= hi)$ error$ "hit upper bound: " ++ show mx
+checkBounds ::
+  (Real a, Show a, Ord a) =>
+  String -> (Bool, a, a) -> ((a,a) -> StdGen -> ((a, a, t), StdGen)) -> IO ()
+checkBounds msg (exclusive,lo,hi) fun = do
+  -- (lo,hi) is [inclusive,exclusive)
+  putStr $ msg ++ ":  "
+  (mn,mx,_) <- getStdRandom (fun (lo,hi))
+  when (mn < lo) $ error $ "broke lower bound: " ++ show mn
+  when (mx > hi) $ error $ "broke upper bound: " ++ show mx
+  when (exclusive && mx >= hi)$ error$ "hit upper bound: " ++ show mx
 
-    let epsilon = 0.1 * (toRational hi - toRational lo)
+  let epsilon = 0.1 * (toRational hi - toRational lo)
 
-    when (toRational (hi - mx) > epsilon)$ error$ "didn't get close enough to upper bound: "++ show mx
-    when (toRational (mn - lo) > epsilon)$ error$ "didn't get close enough to lower bound: "++ show mn
-    putStrLn "Passed" 
+  when (toRational (hi - mx) > epsilon) $ error $ "didn't get close enough to upper bound: "++ show mx
+  when (toRational (mn - lo) > epsilon) $ error $ "didn't get close enough to lower bound: "++ show mn
+  putStrLn "Passed"
 
 boundedRange :: (Num a, Bounded a) => (Bool, a, a)
 boundedRange  = ( False, minBound, maxBound )
 
+trials :: Int
 trials = 5000
 
 -- Keep in mind here that on some architectures (e.g. ARM) CChar, CWchar, and CSigAtomic
 -- are unsigned
-
-main = 
- do 
+main :: IO ()
+main =
+ do
     checkBounds "Int"     boundedRange   (approxBounds random trials (undefined::Int))
     checkBounds "Integer" (False, fromIntegral (minBound::Int), fromIntegral (maxBound::Int))
                                          (approxBounds random trials (undefined::Integer))
@@ -95,9 +95,9 @@ main =
 
   -- Then check all the range-restricted versions:
     checkBounds "Int R"     (False,-100,100)  (approxBounds (randomR (-100,100)) trials (undefined::Int))
-    checkBounds "Integer R" (False,-100000000000000000000,100000000000000000000)
-                                              (approxBounds (randomR (-100000000000000000000,100000000000000000000))
-					                                         trials (undefined::Integer))
+    checkBounds "Integer R"
+      (False,-100000000000000000000,100000000000000000000)
+      (approxBounds (randomR (-100000000000000000000,100000000000000000000)) trials (undefined::Integer))
     checkBounds "Int8 R"    (False,-100,100)  (approxBounds (randomR (-100,100)) trials (undefined::Int8))
     checkBounds "Int8 Rsmall" (False,-50,50)  (approxBounds (randomR (-50,50))   trials (undefined::Int8))
     checkBounds "Int8 Rmini"    (False,3,4)   (approxBounds (randomR (3,4))      trials (undefined::Int8))

--- a/tests/Legacy/T7936.hs
+++ b/tests/Legacy/T7936.hs
@@ -11,4 +11,5 @@ module Legacy.T7936 where
 import System.Random (newStdGen)
 import Control.Monad (replicateM_)
 
+main :: IO ()
 main = replicateM_ 100000 newStdGen

--- a/tests/Legacy/TestRandomIOs.hs
+++ b/tests/Legacy/TestRandomIOs.hs
@@ -15,6 +15,7 @@ import System.Random (randomIO)
 -- the last one.
 -- Should use less than 1Mb of heap space, or we are generating a list of
 -- unevaluated thunks.
+main :: IO ()
 main = do
     rs <- replicateM 5000 randomIO :: IO [Int]
     print $ last rs

--- a/tests/Legacy/TestRandomRs.hs
+++ b/tests/Legacy/TestRandomRs.hs
@@ -12,11 +12,12 @@
 
 module Legacy.TestRandomRs where
 
-import Control.Monad (liftM, replicateM)
+import Control.Monad (liftM)
 import System.Random (randomRs, getStdGen)
 
 -- Return the five-thousandth random number:
 -- Should run in constant space (< 1Mb heap).
+main :: IO ()
 main = do
     n <- (last . take 5000 . randomRs (0, 1000000)) `liftM` getStdGen
     print (n::Integer)


### PR DESCRIPTION
There are no changes to the logic, just a bit of reformatting, removal of tabs, addition of type signatures and removal compilation warnings