### PR TITLE
Add RandomGen instance for 32bit version of splitmix

### DIFF
--- a/System/Random.hs
+++ b/System/Random.hs
@@ -382,6 +382,7 @@ import GHC.Exts
 import GHC.ForeignPtr
 import System.IO.Unsafe (unsafePerformIO)
 import qualified System.Random.SplitMix as SM
+import qualified System.Random.SplitMix32 as SM32
 import GHC.Word
 import GHC.IO (IO(..))
 
@@ -949,6 +950,12 @@ instance RandomGen StdGen where
   genWord32 = SM.nextWord32
   genWord64 = SM.nextWord64
   split = SM.splitSMGen
+
+instance RandomGen SM32.SMGen where
+  next = SM32.nextInt
+  genWord32 = SM32.nextWord32
+  genWord64 = SM32.nextWord64
+  split = SM32.splitSMGen
 
 -- | Constructs a 'StdGen' deterministically.
 mkStdGen :: Int -> StdGen


### PR DESCRIPTION
We forgot the instance for the slower 32bit version of SMGen that is available in `splitmix` package