### PR TITLE
Unbiased floating point number in unit interval

### DIFF
--- a/System/Random.hs
+++ b/System/Random.hs
@@ -230,10 +230,14 @@ instance Random Char
 instance Random Bool
 instance Random Double where
   randomR r g = runGenState g (uniformRM r)
+  {-# INLINE randomR #-}
   random g = runGenState g doubleInUnitIntervalM
+  {-# INLINE random #-}
 instance Random Float where
   randomR r g = runGenState g (uniformRM r)
+  {-# INLINE randomR #-}
   random g = runGenState g floatInUnitIntervalM
+  {-# INLINE random #-}
 
 -------------------------------------------------------------------------------
 -- Global pseudo-random number generator

--- a/System/Random.hs
+++ b/System/Random.hs
@@ -230,10 +230,10 @@ instance Random Char
 instance Random Bool
 instance Random Double where
   randomR r g = runGenState g (uniformRM r)
-  random g = runGenState g (uniformRM (0, 1))
+  random g = runGenState g doubleInUnitIntervalM
 instance Random Float where
   randomR r g = runGenState g (uniformRM r)
-  random g = runGenState g (uniformRM (0, 1))
+  random g = runGenState g floatInUnitIntervalM
 
 -------------------------------------------------------------------------------
 -- Global pseudo-random number generator

--- a/System/Random/Internal.hs
+++ b/System/Random/Internal.hs
@@ -716,15 +716,18 @@ geometricDistr start limit g = go start
 -- | Generates a 'Float' in [0,1].
 floatInUnitIntervalM :: MonadRandom g s m => g s -> m Float
 floatInUnitIntervalM g = do
+  let entropyBits = 64 -- bit size of the word generated initially
   let maxExp = 126 -- exponent of 1.0, decremented by one
   let mantissaBits = 23
-  let bernoulliBits = 64 - mantissaBits - 1
   let carryMask = 2 ^ mantissaBits
   let mantissaMask = (2 ^ mantissaBits) - 1
 
   w <- uniformWord64 g
   let m = w .&. mantissaMask
-  let carry = if (m /= 0) then 0 else ((w .&. carryMask) `unsafeShiftR` mantissaBits)
+  let (carry, bernoulliBits) =
+        if m /= 0
+          then (0, entropyBits - mantissaBits)
+          else (((w .&. carryMask) `unsafeShiftR` mantissaBits), entropyBits - mantissaBits - 1)
 
   d <- case countLeadingZeros w of
     b | b < bernoulliBits -> return b
@@ -737,15 +740,18 @@ floatInUnitIntervalM g = do
 -- | Generates a 'Double' in [0,1].
 doubleInUnitIntervalM :: MonadRandom g s m => g s -> m Double
 doubleInUnitIntervalM g = do
+  let entropyBits = 64 -- bit size of the word generated initially
   let maxExp = 1022 -- exponent of 1.0, decremented by one
   let mantissaBits = 52
-  let bernoulliBits = 64 - mantissaBits - 1
   let carryMask = 2 ^ mantissaBits
   let mantissaMask = (2 ^ mantissaBits) - 1
 
   w <- uniformWord64 g
   let m = w .&. mantissaMask
-  let carry = if (m /= 0) then 0 else ((w .&. carryMask) `unsafeShiftR` mantissaBits)
+  let (carry, bernoulliBits) =
+        if m /= 0
+          then (0, entropyBits - mantissaBits)
+          else (((w .&. carryMask) `unsafeShiftR` mantissaBits), entropyBits - mantissaBits - 1)
 
   d <- case countLeadingZeros w of
     b | b < bernoulliBits -> return b

--- a/System/Random/Internal.hs
+++ b/System/Random/Internal.hs
@@ -672,6 +672,7 @@ instance UniformRange Double where
   uniformRM (l, h) g = do
     x <- doubleInUnitIntervalM g
     return $ (h - l) * x + l
+  {-# INLINE uniformRM #-}
 
 -- | These are now in 'GHC.Float' but unpatched in some versions so
 -- for now we roll our own. See
@@ -698,6 +699,7 @@ instance UniformRange Float where
   uniformRM (l, h) g = do
     x <- floatInUnitIntervalM g
     return $ (h - l) * x + l
+  {-# INLINE uniformRM #-}
 
 -- | Counts the number of failed Bernoulli trials with p=0.5 before the first
 -- success, up to the given limit.

--- a/System/Random/Internal.hs
+++ b/System/Random/Internal.hs
@@ -438,25 +438,20 @@ class Uniform a where
 --
 -- @since 1.2
 class UniformRange a where
-  -- | Generates a value uniformly distributed over the provided range.
+  -- | Generates a value uniformly distributed over the provided range, which
+  -- is interpreted as inclusive in the lower and upper bound.
   --
-  -- *   For /integral types/, the range is interpreted as inclusive in the
-  --     lower and upper bound.
+  -- *   @uniformR (1 :: Int, 4 :: Int)@ should generate values uniformly from
+  --     the set \(\{1,2,3,4\}\)
   --
-  --     As an example, @uniformR (1 :: Int, 4 :: Int)@ should generate values
-  --     uniformly from the set \(\{1,2,3,4\}\).
-  --
-  -- *   For /non-integral types/, the range is interpreted as inclusive in the
-  --     lower bound and exclusive in the upper bound.
-  --
-  --     As an example, @uniformR (1 :: Float, 4 :: Float)@ should generate
-  --     values uniformly from the set \(\{x\;|\;1 \le x \lt 4\}\).
+  -- *   @uniformR (1 :: Float, 4 :: Float)@ should generate values uniformly
+  --     from the set \(\{x\;|\;1 \le x \le 4\}\)
   --
   -- The following law should hold to make the function always defined:
   --
   -- > uniformRM (a, b) = uniformRM (b, a)
   --
-  -- @since 1.2<Paste>
+  -- @since 1.2
   uniformRM :: MonadRandom g s m => (a, a) -> g s -> m a
 
 instance UniformRange Integer where

--- a/test-legacy/RangeTest.hs
+++ b/test-legacy/RangeTest.hs
@@ -70,8 +70,8 @@ main =
     checkBounds "Word16"  boundedRange   (approxBounds random trials (undefined::Word16))
     checkBounds "Word32"  boundedRange   (approxBounds random trials (undefined::Word32))
     checkBounds "Word64"  boundedRange   (approxBounds random trials (undefined::Word64))
-    checkBounds "Double"  (True,0.0,1.0) (approxBounds random trials (undefined::Double))
-    checkBounds "Float"   (True,0.0,1.0) (approxBounds random trials (undefined::Float))
+    checkBounds "Double"  (False,0.0,1.0) (approxBounds random trials (undefined::Double))
+    checkBounds "Float"   (False,0.0,1.0) (approxBounds random trials (undefined::Float))
 
     checkBounds "CChar"      boundedRange (approxBounds random trials (undefined:: CChar))
     checkBounds "CSChar"     boundedRange (approxBounds random trials (undefined:: CSChar))
@@ -111,8 +111,8 @@ main =
     checkBounds "Word16 R"  (False,0,200)     (approxBounds (randomR (0,200))    trials (undefined::Word16))
     checkBounds "Word32 R"  (False,0,200)     (approxBounds (randomR (0,200))    trials (undefined::Word32))
     checkBounds "Word64 R"  (False,0,200)     (approxBounds (randomR (0,200))    trials (undefined::Word64))
-    checkBounds "Double R" (True,10.0,77.0)   (approxBounds (randomR (10,77)) trials (undefined::Double))
-    checkBounds "Float R"  (True,10.0,77.0)   (approxBounds (randomR (10,77)) trials (undefined::Float))
+    checkBounds "Double R" (False,10.0,77.0)  (approxBounds (randomR (10,77)) trials (undefined::Double))
+    checkBounds "Float R"  (False,10.0,77.0)  (approxBounds (randomR (10,77)) trials (undefined::Float))
 
     checkBounds "CChar R"   (False,0,100)        (approxBounds (randomR (0,100))    trials (undefined:: CChar))
     checkBounds "CSChar R"  (False,-100,100)     (approxBounds (randomR (-100,100)) trials (undefined:: CSChar))

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -115,7 +115,7 @@ floatingSpec ::
   => TestTree
 floatingSpec  =
   testGroup ("(" ++ showsType @a ")")
-  [ SC.testProperty "uniformR" $ seeded $ Range.uniformRangeWithinExcluded @_ @a
+  [ SC.testProperty "uniformR" $ seeded $ Range.uniformRangeWithin @_ @a
   -- TODO: Add more tests
   ]
 


### PR DESCRIPTION
Based on http://allendowney.com/research/rand/downey07randfloat.pdf

## Discussion

See #105.

## Performance

Results show the time taken for 100000 iterations.

v1.1 from #111
```
pure/random/Float                        mean 30.63 ms  ( +- 3.753 ms  )
pure/randomR/unbounded/Float             mean 60.17 ms  ( +- 5.086 ms  )

pure/random/Double                       mean 54.18 ms  ( +- 3.741 ms  )
pure/randomR/unbounded/Double            mean 92.29 ms  ( +- 8.487 ms  )
```

current `interface-to-performance` (d03e3254c5975b42bd06a868b53027a530a5ce6a specifically)
```
pure/random/Float                        mean 365.6 μs  ( +- 3.672 μs  )
pure/uniformR/unbounded/Float            mean 357.0 μs  ( +- 24.55 μs  )

pure/random/Double                       mean 454.0 μs  ( +- 4.255 μs  )
pure/uniformR/unbounded/Double           mean 408.9 μs  ( +- 6.579 μs  )
```

with this PR
```
pure/random/Float                        mean 420.7 μs  ( +- 4.416 μs  )
pure/uniformR/unbounded/Float            mean 504.7 μs  ( +- 5.863 μs  )

pure/random/Double                       mean 428.2 μs  ( +- 5.526 μs  )
pure/uniformR/unbounded/Double           mean 451.4 μs  ( +- 11.43 μs  )
```