### PR TITLE
Toplevel docs

### DIFF
--- a/random.cabal
+++ b/random.cabal
@@ -5,11 +5,57 @@ license:            BSD3
 license-file:       LICENSE
 maintainer:         core-libraries-committee@haskell.org
 bug-reports:        https://github.com/haskell/random/issues
-synopsis:           random number library
+synopsis:           Pseudo-random number generation
 description:
-    This package provides a basic random number generation
-    library, including the ability to split random number
-    generators.
+    This package provides basic pseudo-random number generation, including the
+    ability to split random number generators.
+    .
+    == "System.Random": pure pseudo-random number interface
+    .
+    In pure code, use 'System.Random.uniform' and 'System.Random.uniformR' from
+    "System.Random" to generate pseudo-random numbers with a pure pseudo-random
+    number generator like 'System.Random.StdGen'.
+    .
+    As an example, here is how you can simulate rolls of a six-sided die using
+    'System.Random.uniformR':
+    .
+    >>> let roll = flip uniformR (1, 6)   :: RandomGen g => g -> (Word8, g)
+    >>> let rolls = unfoldr (Just . roll) :: RandomGen g => g -> [Word8]
+    >>> let pureGen = mkStdGen 42
+    >>> take 10 (rolls pureGen)           :: [Word8]
+    [1,1,3,2,4,5,3,4,6,2]
+    .
+    See "System.Random" for more details.
+    .
+    == "System.Random.Monad": monadic pseudo-random number interface
+    .
+    In monadic code, use 'System.Random.Monad.uniformM' and
+    'System.Random.Monad.uniformRM' from "System.Random.Monad" to generate
+    pseudo-random numbers with a monadic pseudo-random number generator, or
+    using a monadic adapter.
+    .
+    As an example, here is how you can simulate rolls of a six-sided die using
+    'System.Random.Monad.uniformRM':
+    .
+    >>> let rollM = uniformRM (1, 6)                 :: MonadRandom g s m => g s -> m Word8
+    >>> let pureGen = mkStdGen 42
+    >>> runGenState_ pureGen (replicateM 10 . rollM) :: m [Word8]
+    [1,1,3,2,4,5,3,4,6,2]
+    .
+    The monadic adapter 'System.Random.Monad.runGenState_' is used here to lift
+    the pure pseudo-random number generator @pureGen@ into the
+    'System.Random.Monad.MonadRandom' context.
+    .
+    The monadic interface can also be used with existing monadic pseudo-random
+    number generators. In this example, we use the one provided in the
+    <https://hackage.haskell.org/package/mwc-random mwc-random> package:
+    .
+    >>> let rollM = uniformRM (1, 6)       :: MonadRandom g s m => g s -> m Word8
+    >>> monadicGen <- MWC.create
+    >>> (replicateM 10 . rollM) monadicGen :: m [Word8]
+    [2,3,6,6,4,4,3,1,5,4]
+    .
+    See "System.Random.Monad" for more details.
 
 category:           System
 build-type:         Custom


### PR DESCRIPTION
# Motivation

There are two documented modules now: `System.Random` and `System.Random.Monad`. While one is a submodule of the other in the module hierarchy, they are conceptually at the same level. One would generally use one or the other.

The idea of this PR is to give users answers to the following questions:
- What can this library do for me?
- Where do I need to look for more detailed docs?

# The toplevel docs

The resulting toplevel docs try to give a "feel" for the library and its capabilities through examples, and steer the user towards `System.Random` or `System.Random.Monad`.

# [Preview](https://htmlpreview.github.io/?https://raw.githubusercontent.com/idontgetoutmuch/random/toplevel-docs-preview/docs/index.html)