### PR TITLE
Add basic pure benchmarks

### DIFF
--- a/System/Random/Internal.hs
+++ b/System/Random/Internal.hs
@@ -638,7 +638,7 @@ charToWord32 (C# c#) = W32# (int2Word# (ord# c#))
 {-# INLINE charToWord32 #-}
 
 instance Uniform Char where
-  uniformM g = word32ToChar <$> unsignedBitmaskWithRejectionM uniformM (charToWord32 maxBound) g
+  uniformM g = word32ToChar <$> unbiasedWordMult32 (charToWord32 maxBound) g
   {-# INLINE uniformM #-}
 instance UniformRange Char where
   uniformRM (l, h) g =

--- a/bench/Main.hs
+++ b/bench/Main.hs
@@ -19,7 +19,7 @@ import System.Random
 
 main :: IO ()
 main = do
-  let !sz = 1048576
+  let !sz = 1000000
   defaultMain
     [ bgroup "baseline"
       [ let !stdGen = mkStdGen 1337 in bench "nextWord32" $ nf (genMany SM.nextWord32 stdGen) sz

--- a/bench/Main.hs
+++ b/bench/Main.hs
@@ -1,0 +1,95 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE ExplicitForAll #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Main (main) where
+
+import Data.Int
+import Data.Proxy
+import Data.Typeable
+import Data.Word
+import Foreign.C.Types
+import Gauge.Main
+import System.Random.SplitMix as SM
+
+import System.Random
+
+main :: IO ()
+main = do
+  let !sz = 1048576
+  defaultMain
+    [ bgroup "baseline"
+      [ let !stdGen = mkStdGen 1337 in bench "nextWord32" $ nf (genMany SM.nextWord32 stdGen) sz
+      , let !stdGen = mkStdGen 1337 in bench "nextWord64" $ nf (genMany SM.nextWord64 stdGen) sz
+      , let !stdGen = mkStdGen 1337 in bench "nextInt" $ nf (genMany SM.nextInt stdGen) sz
+      , let !stdGen = mkStdGen 1337 in bench "split" $ nf (genMany SM.splitSMGen stdGen) sz
+      ]
+    , bgroup "pure"
+      [ bgroup "random"
+        [ pureRandomBench @Float sz
+        , pureRandomBench @Double sz
+        , pureRandomBench @Integer sz
+        ]
+      , bgroup "uniform"
+        [ pureUniformBench @Word8 sz
+        , pureUniformBench @Word16 sz
+        , pureUniformBench @Word32 sz
+        , pureUniformBench @Word64 sz
+        , pureUniformBench @Word sz
+        , pureUniformBench @Int8 sz
+        , pureUniformBench @Int16 sz
+        , pureUniformBench @Int32 sz
+        , pureUniformBench @Int64 sz
+        , pureUniformBench @Int sz
+        , pureUniformBench @Char sz
+        , pureUniformBench @Bool sz
+        , pureUniformBench @CBool sz
+        , pureUniformBench @CChar sz
+        , pureUniformBench @CSChar sz
+        , pureUniformBench @CUChar sz
+        , pureUniformBench @CShort sz
+        , pureUniformBench @CUShort sz
+        , pureUniformBench @CInt sz
+        , pureUniformBench @CUInt sz
+        , pureUniformBench @CLong sz
+        , pureUniformBench @CULong sz
+        , pureUniformBench @CPtrdiff sz
+        , pureUniformBench @CSize sz
+        , pureUniformBench @CWchar sz
+        , pureUniformBench @CSigAtomic sz
+        , pureUniformBench @CLLong sz
+        , pureUniformBench @CULLong sz
+        , pureUniformBench @CIntPtr sz
+        , pureUniformBench @CUIntPtr sz
+        , pureUniformBench @CIntMax sz
+        , pureUniformBench @CUIntMax sz
+        ]
+      ]
+    ]
+
+pureRandomBench :: forall a. (Typeable a, Random a) => Int -> Benchmark
+pureRandomBench = let !stdGen = mkStdGen 1337 in pureBench @a (genManyRandom @a stdGen)
+
+pureUniformBench :: forall a. (Typeable a, Uniform a) => Int -> Benchmark
+pureUniformBench = let !stdGen = mkStdGen 1337 in pureBench @a (genManyUniform @a stdGen)
+
+pureBench :: forall a. (Typeable a) => (Int -> ()) -> Int -> Benchmark
+pureBench f sz = bench (showsTypeRep (typeRep (Proxy :: Proxy a)) "") $ nf f sz
+
+genManyRandom :: forall a g. (Random a, RandomGen g) => g -> Int -> ()
+genManyRandom = genMany (random @a)
+
+genManyUniform :: forall a g. (Uniform a, RandomGen g) => g -> Int -> ()
+genManyUniform = genMany (uniform @g @a)
+
+genMany :: (g -> (a, g)) -> g -> Int -> ()
+genMany f g0 n = go g0 0
+  where
+    go g i
+      | i < n =
+        case f g of
+          (x, g') -> x `seq` go g' (i + 1)
+      | otherwise = g `seq` ()

--- a/random.cabal
+++ b/random.cabal
@@ -28,9 +28,11 @@ custom-setup
         cabal-doctest >=1.0.6 && <1.1
 
 library
-    exposed-modules:  System.Random
-                    , System.Random.Internal
-                    , System.Random.Monad
+    exposed-modules:
+        System.Random
+        System.Random.Internal
+        System.Random.Monad
+
     c-sources:        cbits/CastFloatWord.cmm
     default-language: Haskell2010
     ghc-options:      -Wall
@@ -102,3 +104,14 @@ benchmark legacy-bench
         rdtsc -any,
         split >=0.2 && <0.3,
         time >=1.8 && <1.11
+
+benchmark bench
+    type:           exitcode-stdio-1.0
+    main-is:        Main.hs
+    hs-source-dirs: bench
+    ghc-options:    -Wall -O2
+    build-depends:
+        base >=4.10 && <5,
+        gauge >=0.2.3 && <0.3,
+        random -any,
+        splitmix >=0.0.3 && <0.1


### PR DESCRIPTION
Mostly stolen from https://github.com/lehins/haskell-benchmarks/tree/new-random/new-random-benchmarks.

## Current results

All measurements here are for **1048576 iterations**. I changed the number of iterations to 1000000 in a later commit for convenience, but the difference is within the margin of error in most cases, so I didn't update the times listed here in the description.

<pre>$ stack bench random:bench --ba &apos;--small&apos;
[...]
Benchmark bench: RUNNING...
<font color="#4E9A06"><b>baseline/nextWord32                     </b></font> mean <font color="#CC0000"><b>277.8 μs  </b></font>( +- <font color="#CC0000"><b>12.21 μs  </b></font>)
<font color="#4E9A06"><b>baseline/nextWord64                     </b></font> mean <font color="#CC0000"><b>277.3 μs  </b></font>( +- <font color="#CC0000"><b>7.820 μs  </b></font>)
<font color="#4E9A06"><b>baseline/nextInt                        </b></font> mean <font color="#CC0000"><b>276.6 μs  </b></font>( +- <font color="#CC0000"><b>10.38 μs  </b></font>)
<font color="#4E9A06"><b>baseline/split                          </b></font> mean <font color="#CC0000"><b>7.097 ms  </b></font>( +- <font color="#CC0000"><b>60.36 μs  </b></font>)
<font color="#4E9A06"><b>pure/random/Float                       </b></font> mean <font color="#CC0000"><b>4.093 ms  </b></font>( +- <font color="#CC0000"><b>82.97 μs  </b></font>)
<font color="#4E9A06"><b>pure/random/Double                      </b></font> mean <font color="#CC0000"><b>5.275 ms  </b></font>( +- <font color="#CC0000"><b>112.8 μs  </b></font>)
<font color="#4E9A06"><b>pure/random/Integer                     </b></font> mean <font color="#CC0000"><b>4.287 ms  </b></font>( +- <font color="#CC0000"><b>155.3 μs  </b></font>)
<font color="#4E9A06"><b>pure/uniform/Word8                      </b></font> mean <font color="#CC0000"><b>293.3 μs  </b></font>( +- <font color="#CC0000"><b>9.312 μs  </b></font>)
<font color="#4E9A06"><b>pure/uniform/Word16                     </b></font> mean <font color="#CC0000"><b>293.6 μs  </b></font>( +- <font color="#CC0000"><b>25.63 μs  </b></font>)
<font color="#4E9A06"><b>pure/uniform/Word32                     </b></font> mean <font color="#CC0000"><b>297.9 μs  </b></font>( +- <font color="#CC0000"><b>32.12 μs  </b></font>)
<font color="#4E9A06"><b>pure/uniform/Word64                     </b></font> mean <font color="#CC0000"><b>333.0 μs  </b></font>( +- <font color="#CC0000"><b>51.32 μs  </b></font>)
<font color="#4E9A06"><b>pure/uniform/Word                       </b></font> mean <font color="#CC0000"><b>310.5 μs  </b></font>( +- <font color="#CC0000"><b>32.72 μs  </b></font>)
<font color="#4E9A06"><b>pure/uniform/Int8                       </b></font> mean <font color="#CC0000"><b>289.4 μs  </b></font>( +- <font color="#CC0000"><b>7.407 μs  </b></font>)
<font color="#4E9A06"><b>pure/uniform/Int16                      </b></font> mean <font color="#CC0000"><b>287.8 μs  </b></font>( +- <font color="#CC0000"><b>8.539 μs  </b></font>)
<font color="#4E9A06"><b>pure/uniform/Int32                      </b></font> mean <font color="#CC0000"><b>288.0 μs  </b></font>( +- <font color="#CC0000"><b>12.18 μs  </b></font>)
<font color="#4E9A06"><b>pure/uniform/Int64                      </b></font> mean <font color="#CC0000"><b>286.9 μs  </b></font>( +- <font color="#CC0000"><b>8.415 μs  </b></font>)
<font color="#4E9A06"><b>pure/uniform/Int                        </b></font> mean <font color="#CC0000"><b>284.6 μs  </b></font>( +- <font color="#CC0000"><b>6.549 μs  </b></font>)
<font color="#4E9A06"><b>pure/uniform/Char                       </b></font> mean <font color="#CC0000"><b>11.56 ms  </b></font>( +- <font color="#CC0000"><b>111.0 μs  </b></font>)
<font color="#4E9A06"><b>pure/uniform/Bool                       </b></font> mean <font color="#CC0000"><b>281.3 μs  </b></font>( +- <font color="#CC0000"><b>4.134 μs  </b></font>)
<font color="#4E9A06"><b>pure/uniform/CBool                      </b></font> mean <font color="#CC0000"><b>286.4 μs  </b></font>( +- <font color="#CC0000"><b>10.23 μs  </b></font>)
<font color="#4E9A06"><b>pure/uniform/CChar                      </b></font> mean <font color="#CC0000"><b>279.2 μs  </b></font>( +- <font color="#CC0000"><b>3.491 μs  </b></font>)
<font color="#4E9A06"><b>pure/uniform/CSChar                     </b></font> mean <font color="#CC0000"><b>278.6 μs  </b></font>( +- <font color="#CC0000"><b>3.916 μs  </b></font>)
<font color="#4E9A06"><b>pure/uniform/CUChar                     </b></font> mean <font color="#CC0000"><b>278.3 μs  </b></font>( +- <font color="#CC0000"><b>3.818 μs  </b></font>)
<font color="#4E9A06"><b>pure/uniform/CShort                     </b></font> mean <font color="#CC0000"><b>279.8 μs  </b></font>( +- <font color="#CC0000"><b>5.486 μs  </b></font>)
<font color="#4E9A06"><b>pure/uniform/CUShort                    </b></font> mean <font color="#CC0000"><b>294.5 μs  </b></font>( +- <font color="#CC0000"><b>33.58 μs  </b></font>)
<font color="#4E9A06"><b>pure/uniform/CInt                       </b></font> mean <font color="#CC0000"><b>279.2 μs  </b></font>( +- <font color="#CC0000"><b>4.146 μs  </b></font>)
<font color="#4E9A06"><b>pure/uniform/CUInt                      </b></font> mean <font color="#CC0000"><b>288.5 μs  </b></font>( +- <font color="#CC0000"><b>10.21 μs  </b></font>)
<font color="#4E9A06"><b>pure/uniform/CLong                      </b></font> mean <font color="#CC0000"><b>286.3 μs  </b></font>( +- <font color="#CC0000"><b>8.502 μs  </b></font>)
<font color="#4E9A06"><b>pure/uniform/CULong                     </b></font> mean <font color="#CC0000"><b>301.9 μs  </b></font>( +- <font color="#CC0000"><b>34.07 μs  </b></font>)
<font color="#4E9A06"><b>pure/uniform/CPtrdiff                   </b></font> mean <font color="#CC0000"><b>284.5 μs  </b></font>( +- <font color="#CC0000"><b>8.010 μs  </b></font>)
<font color="#4E9A06"><b>pure/uniform/CSize                      </b></font> mean <font color="#CC0000"><b>279.8 μs  </b></font>( +- <font color="#CC0000"><b>4.210 μs  </b></font>)
<font color="#4E9A06"><b>pure/uniform/CWchar                     </b></font> mean <font color="#CC0000"><b>287.0 μs  </b></font>( +- <font color="#CC0000"><b>10.65 μs  </b></font>)
<font color="#4E9A06"><b>pure/uniform/CSigAtomic                 </b></font> mean <font color="#CC0000"><b>285.8 μs  </b></font>( +- <font color="#CC0000"><b>7.762 μs  </b></font>)
<font color="#4E9A06"><b>pure/uniform/CLLong                     </b></font> mean <font color="#CC0000"><b>294.4 μs  </b></font>( +- <font color="#CC0000"><b>12.35 μs  </b></font>)
<font color="#4E9A06"><b>pure/uniform/CULLong                    </b></font> mean <font color="#CC0000"><b>285.9 μs  </b></font>( +- <font color="#CC0000"><b>7.633 μs  </b></font>)
<font color="#4E9A06"><b>pure/uniform/CIntPtr                    </b></font> mean <font color="#CC0000"><b>292.7 μs  </b></font>( +- <font color="#CC0000"><b>12.71 μs  </b></font>)
<font color="#4E9A06"><b>pure/uniform/CUIntPtr                   </b></font> mean <font color="#CC0000"><b>292.6 μs  </b></font>( +- <font color="#CC0000"><b>9.984 μs  </b></font>)
<font color="#4E9A06"><b>pure/uniform/CIntMax                    </b></font> mean <font color="#CC0000"><b>284.5 μs  </b></font>( +- <font color="#CC0000"><b>11.39 μs  </b></font>)
<font color="#4E9A06"><b>pure/uniform/CUIntMax                   </b></font> mean <font color="#CC0000"><b>285.1 μs  </b></font>( +- <font color="#CC0000"><b>8.449 μs  </b></font>)
Benchmark bench: FINISH</pre>

## Optimisation

Note that `Char` is an outlier. It uses rejection sampling under the hood because not every `Word32` is a valid `Char`. However, changing the method used from `unsignedBitmaskWithRejectionM` to `unbiasedWordMult32` (as done in the second commit of this PR) approximately halves the time required to generate a `Char`:

Before
<pre>$ stack bench random:bench --ba &apos;pure/uniform/Char&apos;
[...]
benchmarked <font color="#4E9A06"><b>pure/uniform/Char</b></font>
<font color="#C4A000"><b>time                </b></font> <font color="#CC0000"><b>11.56 ms  </b></font> (11.49 ms .. 11.62 ms)
<font color="#C4A000"><b>                    </b></font> <font color="#CC0000"><b>1.000 R²  </b></font> (1.000 R² .. 1.000 R²)
<font color="#C4A000"><b>mean                </b></font> <font color="#CC0000"><b>11.44 ms  </b></font> (11.39 ms .. 11.47 ms)
<font color="#C4A000"><b>std dev             </b></font> <font color="#CC0000"><b>111.0 μs  </b></font> (74.00 μs .. 177.8 μs)</pre>

After
<pre>$ stack bench random:bench --ba &apos;pure/uniform/Char&apos;
[...]
benchmarked <font color="#4E9A06"><b>pure/uniform/Char</b></font>
<font color="#C4A000"><b>time                </b></font> <font color="#CC0000"><b>6.238 ms  </b></font> (6.205 ms .. 6.275 ms)
<font color="#C4A000"><b>                    </b></font> <font color="#CC0000"><b>1.000 R²  </b></font> (1.000 R² .. 1.000 R²)
<font color="#C4A000"><b>mean                </b></font> <font color="#CC0000"><b>6.457 ms  </b></font> (6.424 ms .. 6.494 ms)
<font color="#C4A000"><b>std dev             </b></font> <font color="#CC0000"><b>105.3 μs  </b></font> (90.97 μs .. 123.8 μs)</pre>