### PR TITLE
Do not merge: Benchmarks on v1.1

### DIFF
--- a/bench/Main.hs
+++ b/bench/Main.hs
@@ -3,71 +3,58 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 module Main (main) where
 
-import Control.Monad
 import Data.Int
 import Data.Proxy
 import Data.Typeable
 import Data.Word
 import Foreign.C.Types
 import Gauge.Main
-import Numeric.Natural (Natural)
-import System.Random.SplitMix as SM
 
-import System.Random.Stateful
+import System.Random
 
 main :: IO ()
 main = do
   let !sz = 100000
-      genLengths =
-        -- create 5000 small lengths that are needed for ShortByteString generation
-        runStateGen (mkStdGen 2020) $ \g -> replicateM 5000 (uniformRM (16 + 1, 16 + 7) g)
   defaultMain
-    [ bgroup "baseline"
-      [ let !smGen = SM.mkSMGen 1337 in bench "nextWord32" $ nf (genMany SM.nextWord32 smGen) sz
-      , let !smGen = SM.mkSMGen 1337 in bench "nextWord64" $ nf (genMany SM.nextWord64 smGen) sz
-      , let !smGen = SM.mkSMGen 1337 in bench "nextInt" $ nf (genMany SM.nextInt smGen) sz
-      , let !smGen = SM.mkSMGen 1337 in bench "split" $ nf (genMany SM.splitSMGen smGen) sz
-      ]
-    , bgroup "pure"
+    [ bgroup "pure"
       [ bgroup "random"
         [ pureRandomBench (Proxy :: Proxy Float) sz
         , pureRandomBench (Proxy :: Proxy Double) sz
         , pureRandomBench (Proxy :: Proxy Integer) sz
+        , pureRandomBench (Proxy :: Proxy Word8) sz
+        , pureRandomBench (Proxy :: Proxy Word16) sz
+        , pureRandomBench (Proxy :: Proxy Word32) sz
+        , pureRandomBench (Proxy :: Proxy Word64) sz
+        , pureRandomBench (Proxy :: Proxy Word) sz
+        , pureRandomBench (Proxy :: Proxy Int8) sz
+        , pureRandomBench (Proxy :: Proxy Int16) sz
+        , pureRandomBench (Proxy :: Proxy Int32) sz
+        , pureRandomBench (Proxy :: Proxy Int64) sz
+        , pureRandomBench (Proxy :: Proxy Int) sz
+        , pureRandomBench (Proxy :: Proxy Char) sz
+        , pureRandomBench (Proxy :: Proxy Bool) sz
+        -- , pureRandomBench (Proxy :: Proxy CBool) sz
+        , pureRandomBench (Proxy :: Proxy CChar) sz
+        , pureRandomBench (Proxy :: Proxy CSChar) sz
+        , pureRandomBench (Proxy :: Proxy CUChar) sz
+        , pureRandomBench (Proxy :: Proxy CShort) sz
+        , pureRandomBench (Proxy :: Proxy CUShort) sz
+        , pureRandomBench (Proxy :: Proxy CInt) sz
+        , pureRandomBench (Proxy :: Proxy CUInt) sz
+        , pureRandomBench (Proxy :: Proxy CLong) sz
+        , pureRandomBench (Proxy :: Proxy CULong) sz
+        , pureRandomBench (Proxy :: Proxy CPtrdiff) sz
+        , pureRandomBench (Proxy :: Proxy CSize) sz
+        , pureRandomBench (Proxy :: Proxy CWchar) sz
+        , pureRandomBench (Proxy :: Proxy CSigAtomic) sz
+        , pureRandomBench (Proxy :: Proxy CLLong) sz
+        , pureRandomBench (Proxy :: Proxy CULLong) sz
+        , pureRandomBench (Proxy :: Proxy CIntPtr) sz
+        , pureRandomBench (Proxy :: Proxy CUIntPtr) sz
+        , pureRandomBench (Proxy :: Proxy CIntMax) sz
+        , pureRandomBench (Proxy :: Proxy CUIntMax) sz
         ]
-      , bgroup "uniform"
-        [ pureUniformBench (Proxy :: Proxy Word8) sz
-        , pureUniformBench (Proxy :: Proxy Word16) sz
-        , pureUniformBench (Proxy :: Proxy Word32) sz
-        , pureUniformBench (Proxy :: Proxy Word64) sz
-        , pureUniformBench (Proxy :: Proxy Word) sz
-        , pureUniformBench (Proxy :: Proxy Int8) sz
-        , pureUniformBench (Proxy :: Proxy Int16) sz
-        , pureUniformBench (Proxy :: Proxy Int32) sz
-        , pureUniformBench (Proxy :: Proxy Int64) sz
-        , pureUniformBench (Proxy :: Proxy Int) sz
-        , pureUniformBench (Proxy :: Proxy Char) sz
-        , pureUniformBench (Proxy :: Proxy Bool) sz
-        , pureUniformBench (Proxy :: Proxy CChar) sz
-        , pureUniformBench (Proxy :: Proxy CSChar) sz
-        , pureUniformBench (Proxy :: Proxy CUChar) sz
-        , pureUniformBench (Proxy :: Proxy CShort) sz
-        , pureUniformBench (Proxy :: Proxy CUShort) sz
-        , pureUniformBench (Proxy :: Proxy CInt) sz
-        , pureUniformBench (Proxy :: Proxy CUInt) sz
-        , pureUniformBench (Proxy :: Proxy CLong) sz
-        , pureUniformBench (Proxy :: Proxy CULong) sz
-        , pureUniformBench (Proxy :: Proxy CPtrdiff) sz
-        , pureUniformBench (Proxy :: Proxy CSize) sz
-        , pureUniformBench (Proxy :: Proxy CWchar) sz
-        , pureUniformBench (Proxy :: Proxy CSigAtomic) sz
-        , pureUniformBench (Proxy :: Proxy CLLong) sz
-        , pureUniformBench (Proxy :: Proxy CULLong) sz
-        , pureUniformBench (Proxy :: Proxy CIntPtr) sz
-        , pureUniformBench (Proxy :: Proxy CUIntPtr) sz
-        , pureUniformBench (Proxy :: Proxy CIntMax) sz
-        , pureUniformBench (Proxy :: Proxy CUIntMax) sz
-        ]
-      , bgroup "uniformR"
+      , bgroup "randomR"
         [ bgroup "full"
           [ pureUniformRFullBench (Proxy :: Proxy Word8) sz
           , pureUniformRFullBench (Proxy :: Proxy Word16) sz
@@ -81,6 +68,7 @@ main = do
           , pureUniformRFullBench (Proxy :: Proxy Int) sz
           , pureUniformRFullBench (Proxy :: Proxy Char) sz
           , pureUniformRFullBench (Proxy :: Proxy Bool) sz
+          -- , pureUniformRFullBench (Proxy :: Proxy CBool) sz
           , pureUniformRFullBench (Proxy :: Proxy CChar) sz
           , pureUniformRFullBench (Proxy :: Proxy CSChar) sz
           , pureUniformRFullBench (Proxy :: Proxy CUChar) sz
@@ -113,6 +101,7 @@ main = do
           , pureUniformRExcludeMaxBench (Proxy :: Proxy Int64) sz
           , pureUniformRExcludeMaxBench (Proxy :: Proxy Int) sz
           , pureUniformRExcludeMaxBench (Proxy :: Proxy Char) sz
+          -- , pureUniformRExcludeMaxBench (Proxy :: Proxy CBool) sz
           , pureUniformRExcludeMaxBench (Proxy :: Proxy Bool) sz
           , pureUniformRExcludeMaxBench (Proxy :: Proxy CChar) sz
           , pureUniformRExcludeMaxBench (Proxy :: Proxy CSChar) sz
@@ -146,6 +135,7 @@ main = do
           , pureUniformRIncludeHalfBench (Proxy :: Proxy Int64) sz
           , pureUniformRIncludeHalfBench (Proxy :: Proxy Int) sz
           , pureUniformRIncludeHalfEnumBench (Proxy :: Proxy Char) sz
+          -- , pureUniformRIncludeHalfEnumBench (Proxy :: Proxy CBool) sz
           , pureUniformRIncludeHalfEnumBench (Proxy :: Proxy Bool) sz
           , pureUniformRIncludeHalfBench (Proxy :: Proxy CChar) sz
           , pureUniformRIncludeHalfBench (Proxy :: Proxy CSChar) sz
@@ -173,14 +163,9 @@ main = do
           , let !i = (10 :: Integer) ^ (100 :: Integer)
                 !range = (-i - 1, i + 1)
             in pureUniformRBench (Proxy :: Proxy Integer) range sz
-          , let !n = (10 :: Natural) ^ (100 :: Natural)
-                !range = (1, n - 1)
-            in pureUniformRBench (Proxy :: Proxy Natural) range sz
-          ]
-        , bgroup "ShortByteString"
-          [ env (pure genLengths) $ \ ~(ns, gen) ->
-              bench "genShortByteString" $
-              nfIO $ runStateGenT_ gen $ \g -> mapM (`uniformShortByteString` g) ns
+          -- , let !n = (10 :: Natural) ^ (100 :: Natural)
+          --       !range = (1, n - 1)
+          --   in pureUniformRBench (Proxy :: Proxy Natural) range sz
           ]
         ]
       ]
@@ -191,13 +176,8 @@ pureRandomBench px =
   let !stdGen = mkStdGen 1337
    in pureBench px (genMany (random :: StdGen -> (a, StdGen)) stdGen)
 
-pureUniformBench :: forall a. (Typeable a, Uniform a) => Proxy a -> Int -> Benchmark
-pureUniformBench px =
-  let !stdGen = mkStdGen 1337
-   in pureBench px (genMany (uniform :: StdGen -> (a, StdGen)) stdGen)
-
 pureUniformRFullBench ::
-     forall a. (Typeable a, UniformRange a, Bounded a)
+     forall a. (Typeable a, Random a, Bounded a)
   => Proxy a
   -> Int
   -> Benchmark
@@ -206,7 +186,7 @@ pureUniformRFullBench px =
    in pureUniformRBench px range
 
 pureUniformRExcludeMaxBench ::
-     forall a. (Typeable a, UniformRange a, Bounded a, Enum a)
+     forall a. (Typeable a, Random a, Bounded a, Enum a)
   => Proxy a
   -> Int
   -> Benchmark
@@ -215,7 +195,7 @@ pureUniformRExcludeMaxBench px =
    in pureUniformRBench px range
 
 pureUniformRIncludeHalfBench ::
-     forall a. (Typeable a, UniformRange a, Bounded a, Integral a)
+     forall a. (Typeable a, Random a, Bounded a, Integral a)
   => Proxy a
   -> Int
   -> Benchmark
@@ -224,7 +204,7 @@ pureUniformRIncludeHalfBench px =
   in pureUniformRBench px range
 
 pureUniformRIncludeHalfEnumBench ::
-     forall a. (Typeable a, UniformRange a, Bounded a, Enum a)
+     forall a. (Typeable a, Random a, Bounded a, Enum a)
   => Proxy a
   -> Int
   -> Benchmark
@@ -233,14 +213,14 @@ pureUniformRIncludeHalfEnumBench px =
   in pureUniformRBench px range
 
 pureUniformRBench ::
-     forall a. (Typeable a, UniformRange a)
+     forall a. (Typeable a, Random a)
   => Proxy a
   -> (a, a)
   -> Int
   -> Benchmark
 pureUniformRBench px range@(!_, !_) =
   let !stdGen = mkStdGen 1337
-  in pureBench px (genMany (uniformR range) stdGen)
+  in pureBench px (genMany (randomR range) stdGen)
 
 pureBench :: forall a. (Typeable a) => Proxy a -> (Int -> ()) -> Int -> Benchmark
 pureBench px f sz = bench (showsTypeRep (typeRep px) "") $ nf f sz

--- a/bench/Main.hs
+++ b/bench/Main.hs
@@ -1,0 +1,255 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+module Main (main) where
+
+import Control.Monad
+import Data.Int
+import Data.Proxy
+import Data.Typeable
+import Data.Word
+import Foreign.C.Types
+import Gauge.Main
+import Numeric.Natural (Natural)
+import System.Random.SplitMix as SM
+
+import System.Random.Stateful
+
+main :: IO ()
+main = do
+  let !sz = 100000
+      genLengths =
+        -- create 5000 small lengths that are needed for ShortByteString generation
+        runStateGen (mkStdGen 2020) $ \g -> replicateM 5000 (uniformRM (16 + 1, 16 + 7) g)
+  defaultMain
+    [ bgroup "baseline"
+      [ let !smGen = SM.mkSMGen 1337 in bench "nextWord32" $ nf (genMany SM.nextWord32 smGen) sz
+      , let !smGen = SM.mkSMGen 1337 in bench "nextWord64" $ nf (genMany SM.nextWord64 smGen) sz
+      , let !smGen = SM.mkSMGen 1337 in bench "nextInt" $ nf (genMany SM.nextInt smGen) sz
+      , let !smGen = SM.mkSMGen 1337 in bench "split" $ nf (genMany SM.splitSMGen smGen) sz
+      ]
+    , bgroup "pure"
+      [ bgroup "random"
+        [ pureRandomBench (Proxy :: Proxy Float) sz
+        , pureRandomBench (Proxy :: Proxy Double) sz
+        , pureRandomBench (Proxy :: Proxy Integer) sz
+        ]
+      , bgroup "uniform"
+        [ pureUniformBench (Proxy :: Proxy Word8) sz
+        , pureUniformBench (Proxy :: Proxy Word16) sz
+        , pureUniformBench (Proxy :: Proxy Word32) sz
+        , pureUniformBench (Proxy :: Proxy Word64) sz
+        , pureUniformBench (Proxy :: Proxy Word) sz
+        , pureUniformBench (Proxy :: Proxy Int8) sz
+        , pureUniformBench (Proxy :: Proxy Int16) sz
+        , pureUniformBench (Proxy :: Proxy Int32) sz
+        , pureUniformBench (Proxy :: Proxy Int64) sz
+        , pureUniformBench (Proxy :: Proxy Int) sz
+        , pureUniformBench (Proxy :: Proxy Char) sz
+        , pureUniformBench (Proxy :: Proxy Bool) sz
+        , pureUniformBench (Proxy :: Proxy CChar) sz
+        , pureUniformBench (Proxy :: Proxy CSChar) sz
+        , pureUniformBench (Proxy :: Proxy CUChar) sz
+        , pureUniformBench (Proxy :: Proxy CShort) sz
+        , pureUniformBench (Proxy :: Proxy CUShort) sz
+        , pureUniformBench (Proxy :: Proxy CInt) sz
+        , pureUniformBench (Proxy :: Proxy CUInt) sz
+        , pureUniformBench (Proxy :: Proxy CLong) sz
+        , pureUniformBench (Proxy :: Proxy CULong) sz
+        , pureUniformBench (Proxy :: Proxy CPtrdiff) sz
+        , pureUniformBench (Proxy :: Proxy CSize) sz
+        , pureUniformBench (Proxy :: Proxy CWchar) sz
+        , pureUniformBench (Proxy :: Proxy CSigAtomic) sz
+        , pureUniformBench (Proxy :: Proxy CLLong) sz
+        , pureUniformBench (Proxy :: Proxy CULLong) sz
+        , pureUniformBench (Proxy :: Proxy CIntPtr) sz
+        , pureUniformBench (Proxy :: Proxy CUIntPtr) sz
+        , pureUniformBench (Proxy :: Proxy CIntMax) sz
+        , pureUniformBench (Proxy :: Proxy CUIntMax) sz
+        ]
+      , bgroup "uniformR"
+        [ bgroup "full"
+          [ pureUniformRFullBench (Proxy :: Proxy Word8) sz
+          , pureUniformRFullBench (Proxy :: Proxy Word16) sz
+          , pureUniformRFullBench (Proxy :: Proxy Word32) sz
+          , pureUniformRFullBench (Proxy :: Proxy Word64) sz
+          , pureUniformRFullBench (Proxy :: Proxy Word) sz
+          , pureUniformRFullBench (Proxy :: Proxy Int8) sz
+          , pureUniformRFullBench (Proxy :: Proxy Int16) sz
+          , pureUniformRFullBench (Proxy :: Proxy Int32) sz
+          , pureUniformRFullBench (Proxy :: Proxy Int64) sz
+          , pureUniformRFullBench (Proxy :: Proxy Int) sz
+          , pureUniformRFullBench (Proxy :: Proxy Char) sz
+          , pureUniformRFullBench (Proxy :: Proxy Bool) sz
+          , pureUniformRFullBench (Proxy :: Proxy CChar) sz
+          , pureUniformRFullBench (Proxy :: Proxy CSChar) sz
+          , pureUniformRFullBench (Proxy :: Proxy CUChar) sz
+          , pureUniformRFullBench (Proxy :: Proxy CShort) sz
+          , pureUniformRFullBench (Proxy :: Proxy CUShort) sz
+          , pureUniformRFullBench (Proxy :: Proxy CInt) sz
+          , pureUniformRFullBench (Proxy :: Proxy CUInt) sz
+          , pureUniformRFullBench (Proxy :: Proxy CLong) sz
+          , pureUniformRFullBench (Proxy :: Proxy CULong) sz
+          , pureUniformRFullBench (Proxy :: Proxy CPtrdiff) sz
+          , pureUniformRFullBench (Proxy :: Proxy CSize) sz
+          , pureUniformRFullBench (Proxy :: Proxy CWchar) sz
+          , pureUniformRFullBench (Proxy :: Proxy CSigAtomic) sz
+          , pureUniformRFullBench (Proxy :: Proxy CLLong) sz
+          , pureUniformRFullBench (Proxy :: Proxy CULLong) sz
+          , pureUniformRFullBench (Proxy :: Proxy CIntPtr) sz
+          , pureUniformRFullBench (Proxy :: Proxy CUIntPtr) sz
+          , pureUniformRFullBench (Proxy :: Proxy CIntMax) sz
+          , pureUniformRFullBench (Proxy :: Proxy CUIntMax) sz
+          ]
+        , bgroup "excludeMax"
+          [ pureUniformRExcludeMaxBench (Proxy :: Proxy Word8) sz
+          , pureUniformRExcludeMaxBench (Proxy :: Proxy Word16) sz
+          , pureUniformRExcludeMaxBench (Proxy :: Proxy Word32) sz
+          , pureUniformRExcludeMaxBench (Proxy :: Proxy Word64) sz
+          , pureUniformRExcludeMaxBench (Proxy :: Proxy Word) sz
+          , pureUniformRExcludeMaxBench (Proxy :: Proxy Int8) sz
+          , pureUniformRExcludeMaxBench (Proxy :: Proxy Int16) sz
+          , pureUniformRExcludeMaxBench (Proxy :: Proxy Int32) sz
+          , pureUniformRExcludeMaxBench (Proxy :: Proxy Int64) sz
+          , pureUniformRExcludeMaxBench (Proxy :: Proxy Int) sz
+          , pureUniformRExcludeMaxBench (Proxy :: Proxy Char) sz
+          , pureUniformRExcludeMaxBench (Proxy :: Proxy Bool) sz
+          , pureUniformRExcludeMaxBench (Proxy :: Proxy CChar) sz
+          , pureUniformRExcludeMaxBench (Proxy :: Proxy CSChar) sz
+          , pureUniformRExcludeMaxBench (Proxy :: Proxy CUChar) sz
+          , pureUniformRExcludeMaxBench (Proxy :: Proxy CShort) sz
+          , pureUniformRExcludeMaxBench (Proxy :: Proxy CUShort) sz
+          , pureUniformRExcludeMaxBench (Proxy :: Proxy CInt) sz
+          , pureUniformRExcludeMaxBench (Proxy :: Proxy CUInt) sz
+          , pureUniformRExcludeMaxBench (Proxy :: Proxy CLong) sz
+          , pureUniformRExcludeMaxBench (Proxy :: Proxy CULong) sz
+          , pureUniformRExcludeMaxBench (Proxy :: Proxy CPtrdiff) sz
+          , pureUniformRExcludeMaxBench (Proxy :: Proxy CSize) sz
+          , pureUniformRExcludeMaxBench (Proxy :: Proxy CWchar) sz
+          , pureUniformRExcludeMaxBench (Proxy :: Proxy CSigAtomic) sz
+          , pureUniformRExcludeMaxBench (Proxy :: Proxy CLLong) sz
+          , pureUniformRExcludeMaxBench (Proxy :: Proxy CULLong) sz
+          , pureUniformRExcludeMaxBench (Proxy :: Proxy CIntPtr) sz
+          , pureUniformRExcludeMaxBench (Proxy :: Proxy CUIntPtr) sz
+          , pureUniformRExcludeMaxBench (Proxy :: Proxy CIntMax) sz
+          , pureUniformRExcludeMaxBench (Proxy :: Proxy CUIntMax) sz
+          ]
+        , bgroup "includeHalf"
+          [ pureUniformRIncludeHalfBench (Proxy :: Proxy Word8) sz
+          , pureUniformRIncludeHalfBench (Proxy :: Proxy Word16) sz
+          , pureUniformRIncludeHalfBench (Proxy :: Proxy Word32) sz
+          , pureUniformRIncludeHalfBench (Proxy :: Proxy Word64) sz
+          , pureUniformRIncludeHalfBench (Proxy :: Proxy Word) sz
+          , pureUniformRIncludeHalfBench (Proxy :: Proxy Int8) sz
+          , pureUniformRIncludeHalfBench (Proxy :: Proxy Int16) sz
+          , pureUniformRIncludeHalfBench (Proxy :: Proxy Int32) sz
+          , pureUniformRIncludeHalfBench (Proxy :: Proxy Int64) sz
+          , pureUniformRIncludeHalfBench (Proxy :: Proxy Int) sz
+          , pureUniformRIncludeHalfEnumBench (Proxy :: Proxy Char) sz
+          , pureUniformRIncludeHalfEnumBench (Proxy :: Proxy Bool) sz
+          , pureUniformRIncludeHalfBench (Proxy :: Proxy CChar) sz
+          , pureUniformRIncludeHalfBench (Proxy :: Proxy CSChar) sz
+          , pureUniformRIncludeHalfBench (Proxy :: Proxy CUChar) sz
+          , pureUniformRIncludeHalfBench (Proxy :: Proxy CShort) sz
+          , pureUniformRIncludeHalfBench (Proxy :: Proxy CUShort) sz
+          , pureUniformRIncludeHalfBench (Proxy :: Proxy CInt) sz
+          , pureUniformRIncludeHalfBench (Proxy :: Proxy CUInt) sz
+          , pureUniformRIncludeHalfBench (Proxy :: Proxy CLong) sz
+          , pureUniformRIncludeHalfBench (Proxy :: Proxy CULong) sz
+          , pureUniformRIncludeHalfBench (Proxy :: Proxy CPtrdiff) sz
+          , pureUniformRIncludeHalfBench (Proxy :: Proxy CSize) sz
+          , pureUniformRIncludeHalfBench (Proxy :: Proxy CWchar) sz
+          , pureUniformRIncludeHalfBench (Proxy :: Proxy CSigAtomic) sz
+          , pureUniformRIncludeHalfBench (Proxy :: Proxy CLLong) sz
+          , pureUniformRIncludeHalfBench (Proxy :: Proxy CULLong) sz
+          , pureUniformRIncludeHalfBench (Proxy :: Proxy CIntPtr) sz
+          , pureUniformRIncludeHalfBench (Proxy :: Proxy CUIntPtr) sz
+          , pureUniformRIncludeHalfBench (Proxy :: Proxy CIntMax) sz
+          , pureUniformRIncludeHalfBench (Proxy :: Proxy CUIntMax) sz
+          ]
+        , bgroup "unbounded"
+          [ pureUniformRBench (Proxy :: Proxy Float) (1.23e-4, 5.67e8) sz
+          , pureUniformRBench (Proxy :: Proxy Double) (1.23e-4, 5.67e8) sz
+          , let !i = (10 :: Integer) ^ (100 :: Integer)
+                !range = (-i - 1, i + 1)
+            in pureUniformRBench (Proxy :: Proxy Integer) range sz
+          , let !n = (10 :: Natural) ^ (100 :: Natural)
+                !range = (1, n - 1)
+            in pureUniformRBench (Proxy :: Proxy Natural) range sz
+          ]
+        , bgroup "ShortByteString"
+          [ env (pure genLengths) $ \ ~(ns, gen) ->
+              bench "genShortByteString" $
+              nfIO $ runStateGenT_ gen $ \g -> mapM (`uniformShortByteString` g) ns
+          ]
+        ]
+      ]
+    ]
+
+pureRandomBench :: forall a. (Typeable a, Random a) => Proxy a -> Int -> Benchmark
+pureRandomBench px =
+  let !stdGen = mkStdGen 1337
+   in pureBench px (genMany (random :: StdGen -> (a, StdGen)) stdGen)
+
+pureUniformBench :: forall a. (Typeable a, Uniform a) => Proxy a -> Int -> Benchmark
+pureUniformBench px =
+  let !stdGen = mkStdGen 1337
+   in pureBench px (genMany (uniform :: StdGen -> (a, StdGen)) stdGen)
+
+pureUniformRFullBench ::
+     forall a. (Typeable a, UniformRange a, Bounded a)
+  => Proxy a
+  -> Int
+  -> Benchmark
+pureUniformRFullBench px =
+  let range = (minBound :: a, maxBound :: a)
+   in pureUniformRBench px range
+
+pureUniformRExcludeMaxBench ::
+     forall a. (Typeable a, UniformRange a, Bounded a, Enum a)
+  => Proxy a
+  -> Int
+  -> Benchmark
+pureUniformRExcludeMaxBench px =
+  let range = (minBound :: a, pred (maxBound :: a))
+   in pureUniformRBench px range
+
+pureUniformRIncludeHalfBench ::
+     forall a. (Typeable a, UniformRange a, Bounded a, Integral a)
+  => Proxy a
+  -> Int
+  -> Benchmark
+pureUniformRIncludeHalfBench px =
+  let range = ((minBound :: a) + 1, ((maxBound :: a) `div` 2) + 1)
+  in pureUniformRBench px range
+
+pureUniformRIncludeHalfEnumBench ::
+     forall a. (Typeable a, UniformRange a, Bounded a, Enum a)
+  => Proxy a
+  -> Int
+  -> Benchmark
+pureUniformRIncludeHalfEnumBench px =
+  let range = (succ (minBound :: a), toEnum ((fromEnum (maxBound :: a) `div` 2) + 1))
+  in pureUniformRBench px range
+
+pureUniformRBench ::
+     forall a. (Typeable a, UniformRange a)
+  => Proxy a
+  -> (a, a)
+  -> Int
+  -> Benchmark
+pureUniformRBench px range@(!_, !_) =
+  let !stdGen = mkStdGen 1337
+  in pureBench px (genMany (uniformR range) stdGen)
+
+pureBench :: forall a. (Typeable a) => Proxy a -> (Int -> ()) -> Int -> Benchmark
+pureBench px f sz = bench (showsTypeRep (typeRep px) "") $ nf f sz
+
+genMany :: (g -> (a, g)) -> g -> Int -> ()
+genMany f g0 n = go g0 0
+  where
+    go g i
+      | i < n =
+        case f g of
+          (x, g') -> x `seq` go g' (i + 1)
+      | otherwise = g `seq` ()

--- a/random.cabal
+++ b/random.cabal
@@ -68,3 +68,13 @@ Test-Suite TestRandomIOs
     hs-source-dirs: tests
     build-depends:  base >= 3 && < 5, random
     ghc-options:    -rtsopts -O2
+
+benchmark bench
+    type:           exitcode-stdio-1.0
+    main-is:        Main.hs
+    hs-source-dirs: bench
+    ghc-options:    -Wall -O2
+    build-depends:
+        base >=4.10 && <5,
+        gauge >=0.2.3 && <0.3,
+        random -any

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,4 @@
+resolver: lts-15.1
+packages:
+- .
+extra-deps: []


### PR DESCRIPTION
This PR targets `master` and is not meant to be merged. It's meant as a long-lived branch where we regularly backport benchmarks for comparison.

This is the time taken for 100000 iterations.

<pre>$ stack bench random:bench --ba &apos;--small&apos;
[...]
Benchmark bench: RUNNING...
<font color="#4E9A06"><b>pure/random/Float                       </b></font> mean <font color="#CC0000"><b>30.63 ms  </b></font>( +- <font color="#CC0000"><b>3.753 ms  </b></font>)
<font color="#4E9A06"><b>pure/random/Double                      </b></font> mean <font color="#CC0000"><b>54.18 ms  </b></font>( +- <font color="#CC0000"><b>3.741 ms  </b></font>)
<font color="#4E9A06"><b>pure/random/Integer                     </b></font> mean <font color="#CC0000"><b>43.56 ms  </b></font>( +- <font color="#CC0000"><b>280.9 μs  </b></font>)
<font color="#4E9A06"><b>pure/random/Word8                       </b></font> mean <font color="#CC0000"><b>13.97 ms  </b></font>( +- <font color="#CC0000"><b>122.4 μs  </b></font>)
<font color="#4E9A06"><b>pure/random/Word16                      </b></font> mean <font color="#CC0000"><b>14.61 ms  </b></font>( +- <font color="#CC0000"><b>797.7 μs  </b></font>)
<font color="#4E9A06"><b>pure/random/Word32                      </b></font> mean <font color="#CC0000"><b>22.88 ms  </b></font>( +- <font color="#CC0000"><b>180.1 μs  </b></font>)
<font color="#4E9A06"><b>pure/random/Word64                      </b></font> mean <font color="#CC0000"><b>45.57 ms  </b></font>( +- <font color="#CC0000"><b>320.6 μs  </b></font>)
<font color="#4E9A06"><b>pure/random/Word                        </b></font> mean <font color="#CC0000"><b>45.98 ms  </b></font>( +- <font color="#CC0000"><b>1.225 ms  </b></font>)
<font color="#4E9A06"><b>pure/random/Int8                        </b></font> mean <font color="#CC0000"><b>14.79 ms  </b></font>( +- <font color="#CC0000"><b>165.4 μs  </b></font>)
<font color="#4E9A06"><b>pure/random/Int16                       </b></font> mean <font color="#CC0000"><b>14.57 ms  </b></font>( +- <font color="#CC0000"><b>132.5 μs  </b></font>)
<font color="#4E9A06"><b>pure/random/Int32                       </b></font> mean <font color="#CC0000"><b>22.65 ms  </b></font>( +- <font color="#CC0000"><b>441.5 μs  </b></font>)
<font color="#4E9A06"><b>pure/random/Int64                       </b></font> mean <font color="#CC0000"><b>44.20 ms  </b></font>( +- <font color="#CC0000"><b>1.609 ms  </b></font>)
<font color="#4E9A06"><b>pure/random/Int                         </b></font> mean <font color="#CC0000"><b>46.91 ms  </b></font>( +- <font color="#CC0000"><b>2.589 ms  </b></font>)
<font color="#4E9A06"><b>pure/random/Char                        </b></font> mean <font color="#CC0000"><b>19.05 ms  </b></font>( +- <font color="#CC0000"><b>1.102 ms  </b></font>)
<font color="#4E9A06"><b>pure/random/Bool                        </b></font> mean <font color="#CC0000"><b>19.12 ms  </b></font>( +- <font color="#CC0000"><b>370.7 μs  </b></font>)
<font color="#4E9A06"><b>pure/random/CChar                       </b></font> mean <font color="#CC0000"><b>15.40 ms  </b></font>( +- <font color="#CC0000"><b>753.4 μs  </b></font>)
<font color="#4E9A06"><b>pure/random/CSChar                      </b></font> mean <font color="#CC0000"><b>14.60 ms  </b></font>( +- <font color="#CC0000"><b>216.1 μs  </b></font>)
<font color="#4E9A06"><b>pure/random/CUChar                      </b></font> mean <font color="#CC0000"><b>14.45 ms  </b></font>( +- <font color="#CC0000"><b>736.6 μs  </b></font>)
<font color="#4E9A06"><b>pure/random/CShort                      </b></font> mean <font color="#CC0000"><b>14.55 ms  </b></font>( +- <font color="#CC0000"><b>126.9 μs  </b></font>)
<font color="#4E9A06"><b>pure/random/CUShort                     </b></font> mean <font color="#CC0000"><b>14.61 ms  </b></font>( +- <font color="#CC0000"><b>687.0 μs  </b></font>)
<font color="#4E9A06"><b>pure/random/CInt                        </b></font> mean <font color="#CC0000"><b>22.79 ms  </b></font>( +- <font color="#CC0000"><b>317.2 μs  </b></font>)
<font color="#4E9A06"><b>pure/random/CUInt                       </b></font> mean <font color="#CC0000"><b>21.84 ms  </b></font>( +- <font color="#CC0000"><b>228.6 μs  </b></font>)
<font color="#4E9A06"><b>pure/random/CLong                       </b></font> mean <font color="#CC0000"><b>45.43 ms  </b></font>( +- <font color="#CC0000"><b>591.7 μs  </b></font>)
<font color="#4E9A06"><b>pure/random/CULong                      </b></font> mean <font color="#CC0000"><b>43.38 ms  </b></font>( +- <font color="#CC0000"><b>610.5 μs  </b></font>)
<font color="#4E9A06"><b>pure/random/CPtrdiff                    </b></font> mean <font color="#CC0000"><b>46.27 ms  </b></font>( +- <font color="#CC0000"><b>2.069 ms  </b></font>)
<font color="#4E9A06"><b>pure/random/CSize                       </b></font> mean <font color="#CC0000"><b>44.65 ms  </b></font>( +- <font color="#CC0000"><b>1.945 ms  </b></font>)
<font color="#4E9A06"><b>pure/random/CWchar                      </b></font> mean <font color="#CC0000"><b>22.69 ms  </b></font>( +- <font color="#CC0000"><b>223.5 μs  </b></font>)
<font color="#4E9A06"><b>pure/random/CSigAtomic                  </b></font> mean <font color="#CC0000"><b>26.34 ms  </b></font>( +- <font color="#CC0000"><b>3.080 ms  </b></font>)
<font color="#4E9A06"><b>pure/random/CLLong                      </b></font> mean <font color="#CC0000"><b>50.13 ms  </b></font>( +- <font color="#CC0000"><b>2.743 ms  </b></font>)
<font color="#4E9A06"><b>pure/random/CULLong                     </b></font> mean <font color="#CC0000"><b>49.09 ms  </b></font>( +- <font color="#CC0000"><b>5.879 ms  </b></font>)
<font color="#4E9A06"><b>pure/random/CIntPtr                     </b></font> mean <font color="#CC0000"><b>49.22 ms  </b></font>( +- <font color="#CC0000"><b>6.255 ms  </b></font>)
<font color="#4E9A06"><b>pure/random/CUIntPtr                    </b></font> mean <font color="#CC0000"><b>50.74 ms  </b></font>( +- <font color="#CC0000"><b>7.632 ms  </b></font>)
<font color="#4E9A06"><b>pure/random/CIntMax                     </b></font> mean <font color="#CC0000"><b>46.54 ms  </b></font>( +- <font color="#CC0000"><b>1.519 ms  </b></font>)
<font color="#4E9A06"><b>pure/random/CUIntMax                    </b></font> mean <font color="#CC0000"><b>45.84 ms  </b></font>( +- <font color="#CC0000"><b>2.030 ms  </b></font>)
<font color="#4E9A06"><b>pure/randomR/full/Word8                 </b></font> mean <font color="#CC0000"><b>18.74 ms  </b></font>( +- <font color="#CC0000"><b>415.9 μs  </b></font>)
<font color="#4E9A06"><b>pure/randomR/full/Word16                </b></font> mean <font color="#CC0000"><b>18.54 ms  </b></font>( +- <font color="#CC0000"><b>501.8 μs  </b></font>)
<font color="#4E9A06"><b>pure/randomR/full/Word32                </b></font> mean <font color="#CC0000"><b>29.78 ms  </b></font>( +- <font color="#CC0000"><b>906.2 μs  </b></font>)
<font color="#4E9A06"><b>pure/randomR/full/Word64                </b></font> mean <font color="#CC0000"><b>55.32 ms  </b></font>( +- <font color="#CC0000"><b>1.097 ms  </b></font>)
<font color="#4E9A06"><b>pure/randomR/full/Word                  </b></font> mean <font color="#CC0000"><b>57.30 ms  </b></font>( +- <font color="#CC0000"><b>3.062 ms  </b></font>)
<font color="#4E9A06"><b>pure/randomR/full/Int8                  </b></font> mean <font color="#CC0000"><b>20.15 ms  </b></font>( +- <font color="#CC0000"><b>1.822 ms  </b></font>)
<font color="#4E9A06"><b>pure/randomR/full/Int16                 </b></font> mean <font color="#CC0000"><b>19.41 ms  </b></font>( +- <font color="#CC0000"><b>1.000 ms  </b></font>)
<font color="#4E9A06"><b>pure/randomR/full/Int32                 </b></font> mean <font color="#CC0000"><b>31.35 ms  </b></font>( +- <font color="#CC0000"><b>564.5 μs  </b></font>)
<font color="#4E9A06"><b>pure/randomR/full/Int64                 </b></font> mean <font color="#CC0000"><b>55.51 ms  </b></font>( +- <font color="#CC0000"><b>4.204 ms  </b></font>)
<font color="#4E9A06"><b>pure/randomR/full/Int                   </b></font> mean <font color="#CC0000"><b>57.90 ms  </b></font>( +- <font color="#CC0000"><b>4.530 ms  </b></font>)
<font color="#4E9A06"><b>pure/randomR/full/Char                  </b></font> mean <font color="#CC0000"><b>20.26 ms  </b></font>( +- <font color="#CC0000"><b>2.032 ms  </b></font>)
<font color="#4E9A06"><b>pure/randomR/full/Bool                  </b></font> mean <font color="#CC0000"><b>20.99 ms  </b></font>( +- <font color="#CC0000"><b>1.317 ms  </b></font>)
<font color="#4E9A06"><b>pure/randomR/full/CChar                 </b></font> mean <font color="#CC0000"><b>19.56 ms  </b></font>( +- <font color="#CC0000"><b>1.778 ms  </b></font>)
<font color="#4E9A06"><b>pure/randomR/full/CSChar                </b></font> mean <font color="#CC0000"><b>19.39 ms  </b></font>( +- <font color="#CC0000"><b>904.6 μs  </b></font>)
<font color="#4E9A06"><b>pure/randomR/full/CUChar                </b></font> mean <font color="#CC0000"><b>18.09 ms  </b></font>( +- <font color="#CC0000"><b>382.4 μs  </b></font>)
<font color="#4E9A06"><b>pure/randomR/full/CShort                </b></font> mean <font color="#CC0000"><b>18.92 ms  </b></font>( +- <font color="#CC0000"><b>793.2 μs  </b></font>)
<font color="#4E9A06"><b>pure/randomR/full/CUShort               </b></font> mean <font color="#CC0000"><b>18.73 ms  </b></font>( +- <font color="#CC0000"><b>1.048 ms  </b></font>)
<font color="#4E9A06"><b>pure/randomR/full/CInt                  </b></font> mean <font color="#CC0000"><b>30.04 ms  </b></font>( +- <font color="#CC0000"><b>446.3 μs  </b></font>)
<font color="#4E9A06"><b>pure/randomR/full/CUInt                 </b></font> mean <font color="#CC0000"><b>29.52 ms  </b></font>( +- <font color="#CC0000"><b>697.5 μs  </b></font>)
<font color="#4E9A06"><b>pure/randomR/full/CLong                 </b></font> mean <font color="#CC0000"><b>54.68 ms  </b></font>( +- <font color="#CC0000"><b>1.499 ms  </b></font>)
<font color="#4E9A06"><b>pure/randomR/full/CULong                </b></font> mean <font color="#CC0000"><b>56.45 ms  </b></font>( +- <font color="#CC0000"><b>3.207 ms  </b></font>)
<font color="#4E9A06"><b>pure/randomR/full/CPtrdiff              </b></font> mean <font color="#CC0000"><b>56.96 ms  </b></font>( +- <font color="#CC0000"><b>3.824 ms  </b></font>)
<font color="#4E9A06"><b>pure/randomR/full/CSize                 </b></font> mean <font color="#CC0000"><b>55.60 ms  </b></font>( +- <font color="#CC0000"><b>4.298 ms  </b></font>)
<font color="#4E9A06"><b>pure/randomR/full/CWchar                </b></font> mean <font color="#CC0000"><b>29.23 ms  </b></font>( +- <font color="#CC0000"><b>472.7 μs  </b></font>)
<font color="#4E9A06"><b>pure/randomR/full/CSigAtomic            </b></font> mean <font color="#CC0000"><b>33.60 ms  </b></font>( +- <font color="#CC0000"><b>3.543 ms  </b></font>)
<font color="#4E9A06"><b>pure/randomR/full/CLLong                </b></font> mean <font color="#CC0000"><b>63.56 ms  </b></font>( +- <font color="#CC0000"><b>15.16 ms  </b></font>)
<font color="#4E9A06"><b>pure/randomR/full/CULLong               </b></font> mean <font color="#CC0000"><b>53.21 ms  </b></font>( +- <font color="#CC0000"><b>1.380 ms  </b></font>)
<font color="#4E9A06"><b>pure/randomR/full/CIntPtr               </b></font> mean <font color="#CC0000"><b>56.56 ms  </b></font>( +- <font color="#CC0000"><b>2.942 ms  </b></font>)
<font color="#4E9A06"><b>pure/randomR/full/CUIntPtr              </b></font> mean <font color="#CC0000"><b>54.29 ms  </b></font>( +- <font color="#CC0000"><b>1.037 ms  </b></font>)
<font color="#4E9A06"><b>pure/randomR/full/CIntMax               </b></font> mean <font color="#CC0000"><b>54.77 ms  </b></font>( +- <font color="#CC0000"><b>2.211 ms  </b></font>)
<font color="#4E9A06"><b>pure/randomR/full/CUIntMax              </b></font> mean <font color="#CC0000"><b>56.42 ms  </b></font>( +- <font color="#CC0000"><b>2.947 ms  </b></font>)
<font color="#4E9A06"><b>pure/randomR/excludeMax/Word8           </b></font> mean <font color="#CC0000"><b>20.17 ms  </b></font>( +- <font color="#CC0000"><b>2.182 ms  </b></font>)
<font color="#4E9A06"><b>pure/randomR/excludeMax/Word16          </b></font> mean <font color="#CC0000"><b>18.21 ms  </b></font>( +- <font color="#CC0000"><b>285.1 μs  </b></font>)
<font color="#4E9A06"><b>pure/randomR/excludeMax/Word32          </b></font> mean <font color="#CC0000"><b>29.55 ms  </b></font>( +- <font color="#CC0000"><b>597.9 μs  </b></font>)
<font color="#4E9A06"><b>pure/randomR/excludeMax/Word64          </b></font> mean <font color="#CC0000"><b>50.27 ms  </b></font>( +- <font color="#CC0000"><b>1.643 ms  </b></font>)
<font color="#4E9A06"><b>pure/randomR/excludeMax/Word            </b></font> mean <font color="#CC0000"><b>52.96 ms  </b></font>( +- <font color="#CC0000"><b>3.181 ms  </b></font>)
<font color="#4E9A06"><b>pure/randomR/excludeMax/Int8            </b></font> mean <font color="#CC0000"><b>19.35 ms  </b></font>( +- <font color="#CC0000"><b>723.0 μs  </b></font>)
<font color="#4E9A06"><b>pure/randomR/excludeMax/Int16           </b></font> mean <font color="#CC0000"><b>18.96 ms  </b></font>( +- <font color="#CC0000"><b>867.3 μs  </b></font>)
<font color="#4E9A06"><b>pure/randomR/excludeMax/Int32           </b></font> mean <font color="#CC0000"><b>31.12 ms  </b></font>( +- <font color="#CC0000"><b>1.640 ms  </b></font>)
<font color="#4E9A06"><b>pure/randomR/excludeMax/Int64           </b></font> mean <font color="#CC0000"><b>53.86 ms  </b></font>( +- <font color="#CC0000"><b>2.772 ms  </b></font>)
<font color="#4E9A06"><b>pure/randomR/excludeMax/Int             </b></font> mean <font color="#CC0000"><b>51.41 ms  </b></font>( +- <font color="#CC0000"><b>738.3 μs  </b></font>)
<font color="#4E9A06"><b>pure/randomR/excludeMax/Char            </b></font> mean <font color="#CC0000"><b>18.92 ms  </b></font>( +- <font color="#CC0000"><b>498.5 μs  </b></font>)
<font color="#4E9A06"><b>pure/randomR/excludeMax/Bool            </b></font> mean <font color="#CC0000"><b>18.38 ms  </b></font>( +- <font color="#CC0000"><b>2.869 ms  </b></font>)
<font color="#4E9A06"><b>pure/randomR/excludeMax/CChar           </b></font> mean <font color="#CC0000"><b>21.89 ms  </b></font>( +- <font color="#CC0000"><b>1.502 ms  </b></font>)
<font color="#4E9A06"><b>pure/randomR/excludeMax/CSChar          </b></font> mean <font color="#CC0000"><b>20.03 ms  </b></font>( +- <font color="#CC0000"><b>1.568 ms  </b></font>)
<font color="#4E9A06"><b>pure/randomR/excludeMax/CUChar          </b></font> mean <font color="#CC0000"><b>21.80 ms  </b></font>( +- <font color="#CC0000"><b>4.873 ms  </b></font>)
<font color="#4E9A06"><b>pure/randomR/excludeMax/CShort          </b></font> mean <font color="#CC0000"><b>19.54 ms  </b></font>( +- <font color="#CC0000"><b>486.9 μs  </b></font>)
<font color="#4E9A06"><b>pure/randomR/excludeMax/CUShort         </b></font> mean <font color="#CC0000"><b>19.22 ms  </b></font>( +- <font color="#CC0000"><b>1.078 ms  </b></font>)
<font color="#4E9A06"><b>pure/randomR/excludeMax/CInt            </b></font> mean <font color="#CC0000"><b>30.84 ms  </b></font>( +- <font color="#CC0000"><b>1.533 ms  </b></font>)
<font color="#4E9A06"><b>pure/randomR/excludeMax/CUInt           </b></font> mean <font color="#CC0000"><b>30.05 ms  </b></font>( +- <font color="#CC0000"><b>1.054 ms  </b></font>)
<font color="#4E9A06"><b>pure/randomR/excludeMax/CLong           </b></font> mean <font color="#CC0000"><b>52.38 ms  </b></font>( +- <font color="#CC0000"><b>1.338 ms  </b></font>)
<font color="#4E9A06"><b>pure/randomR/excludeMax/CULong          </b></font> mean <font color="#CC0000"><b>51.10 ms  </b></font>( +- <font color="#CC0000"><b>1.459 ms  </b></font>)
<font color="#4E9A06"><b>pure/randomR/excludeMax/CPtrdiff        </b></font> mean <font color="#CC0000"><b>52.46 ms  </b></font>( +- <font color="#CC0000"><b>1.885 ms  </b></font>)
<font color="#4E9A06"><b>pure/randomR/excludeMax/CSize           </b></font> mean <font color="#CC0000"><b>51.21 ms  </b></font>( +- <font color="#CC0000"><b>2.680 ms  </b></font>)
<font color="#4E9A06"><b>pure/randomR/excludeMax/CWchar          </b></font> mean <font color="#CC0000"><b>31.90 ms  </b></font>( +- <font color="#CC0000"><b>1.504 ms  </b></font>)
<font color="#4E9A06"><b>pure/randomR/excludeMax/CSigAtomic      </b></font> mean <font color="#CC0000"><b>33.01 ms  </b></font>( +- <font color="#CC0000"><b>4.443 ms  </b></font>)
<font color="#4E9A06"><b>pure/randomR/excludeMax/CLLong          </b></font> mean <font color="#CC0000"><b>49.39 ms  </b></font>( +- <font color="#CC0000"><b>1.207 ms  </b></font>)
<font color="#4E9A06"><b>pure/randomR/excludeMax/CULLong         </b></font> mean <font color="#CC0000"><b>51.46 ms  </b></font>( +- <font color="#CC0000"><b>2.940 ms  </b></font>)
<font color="#4E9A06"><b>pure/randomR/excludeMax/CIntPtr         </b></font> mean <font color="#CC0000"><b>53.29 ms  </b></font>( +- <font color="#CC0000"><b>3.456 ms  </b></font>)
<font color="#4E9A06"><b>pure/randomR/excludeMax/CUIntPtr        </b></font> mean <font color="#CC0000"><b>48.06 ms  </b></font>( +- <font color="#CC0000"><b>805.5 μs  </b></font>)
<font color="#4E9A06"><b>pure/randomR/excludeMax/CIntMax         </b></font> mean <font color="#CC0000"><b>54.91 ms  </b></font>( +- <font color="#CC0000"><b>5.206 ms  </b></font>)
<font color="#4E9A06"><b>pure/randomR/excludeMax/CUIntMax        </b></font> mean <font color="#CC0000"><b>63.10 ms  </b></font>( +- <font color="#CC0000"><b>8.407 ms  </b></font>)
<font color="#4E9A06"><b>pure/randomR/includeHalf/Word8          </b></font> mean <font color="#CC0000"><b>24.14 ms  </b></font>( +- <font color="#CC0000"><b>7.551 ms  </b></font>)
<font color="#4E9A06"><b>pure/randomR/includeHalf/Word16         </b></font> mean <font color="#CC0000"><b>43.41 ms  </b></font>( +- <font color="#CC0000"><b>5.973 ms  </b></font>)
<font color="#4E9A06"><b>pure/randomR/includeHalf/Word32         </b></font> mean <font color="#CC0000"><b>61.66 ms  </b></font>( +- <font color="#CC0000"><b>13.50 ms  </b></font>)
<font color="#4E9A06"><b>pure/randomR/includeHalf/Word64         </b></font> mean <font color="#CC0000"><b>99.57 ms  </b></font>( +- <font color="#CC0000"><b>54.87 ms  </b></font>)
<font color="#4E9A06"><b>pure/randomR/includeHalf/Word           </b></font> mean <font color="#CC0000"><b>56.98 ms  </b></font>( +- <font color="#CC0000"><b>9.870 ms  </b></font>)
<font color="#4E9A06"><b>pure/randomR/includeHalf/Int8           </b></font> mean <font color="#CC0000"><b>21.24 ms  </b></font>( +- <font color="#CC0000"><b>2.317 ms  </b></font>)
<font color="#4E9A06"><b>pure/randomR/includeHalf/Int16          </b></font> mean <font color="#CC0000"><b>19.32 ms  </b></font>( +- <font color="#CC0000"><b>915.1 μs  </b></font>)
<font color="#4E9A06"><b>pure/randomR/includeHalf/Int32          </b></font> mean <font color="#CC0000"><b>34.83 ms  </b></font>( +- <font color="#CC0000"><b>6.819 ms  </b></font>)
<font color="#4E9A06"><b>pure/randomR/includeHalf/Int64          </b></font> mean <font color="#CC0000"><b>59.31 ms  </b></font>( +- <font color="#CC0000"><b>9.598 ms  </b></font>)
<font color="#4E9A06"><b>pure/randomR/includeHalf/Int            </b></font> mean <font color="#CC0000"><b>50.71 ms  </b></font>( +- <font color="#CC0000"><b>2.178 ms  </b></font>)
<font color="#4E9A06"><b>pure/randomR/includeHalf/Char           </b></font> mean <font color="#CC0000"><b>19.53 ms  </b></font>( +- <font color="#CC0000"><b>1.376 ms  </b></font>)
<font color="#4E9A06"><b>pure/randomR/includeHalf/Bool           </b></font> mean <font color="#CC0000"><b>20.50 ms  </b></font>( +- <font color="#CC0000"><b>2.718 ms  </b></font>)
<font color="#4E9A06"><b>pure/randomR/includeHalf/CChar          </b></font> mean <font color="#CC0000"><b>19.95 ms  </b></font>( +- <font color="#CC0000"><b>2.114 ms  </b></font>)
<font color="#4E9A06"><b>pure/randomR/includeHalf/CSChar         </b></font> mean <font color="#CC0000"><b>20.56 ms  </b></font>( +- <font color="#CC0000"><b>1.969 ms  </b></font>)
<font color="#4E9A06"><b>pure/randomR/includeHalf/CUChar         </b></font> mean <font color="#CC0000"><b>19.35 ms  </b></font>( +- <font color="#CC0000"><b>797.1 μs  </b></font>)
<font color="#4E9A06"><b>pure/randomR/includeHalf/CShort         </b></font> mean <font color="#CC0000"><b>19.64 ms  </b></font>( +- <font color="#CC0000"><b>1.105 ms  </b></font>)
<font color="#4E9A06"><b>pure/randomR/includeHalf/CUShort        </b></font> mean <font color="#CC0000"><b>18.49 ms  </b></font>( +- <font color="#CC0000"><b>350.9 μs  </b></font>)
<font color="#4E9A06"><b>pure/randomR/includeHalf/CInt           </b></font> mean <font color="#CC0000"><b>30.42 ms  </b></font>( +- <font color="#CC0000"><b>1.507 ms  </b></font>)
<font color="#4E9A06"><b>pure/randomR/includeHalf/CUInt          </b></font> mean <font color="#CC0000"><b>29.35 ms  </b></font>( +- <font color="#CC0000"><b>658.6 μs  </b></font>)
<font color="#4E9A06"><b>pure/randomR/includeHalf/CLong          </b></font> mean <font color="#CC0000"><b>49.34 ms  </b></font>( +- <font color="#CC0000"><b>490.6 μs  </b></font>)
<font color="#4E9A06"><b>pure/randomR/includeHalf/CULong         </b></font> mean <font color="#CC0000"><b>48.51 ms  </b></font>( +- <font color="#CC0000"><b>598.0 μs  </b></font>)
<font color="#4E9A06"><b>pure/randomR/includeHalf/CPtrdiff       </b></font> mean <font color="#CC0000"><b>50.53 ms  </b></font>( +- <font color="#CC0000"><b>1.676 ms  </b></font>)
<font color="#4E9A06"><b>pure/randomR/includeHalf/CSize          </b></font> mean <font color="#CC0000"><b>48.48 ms  </b></font>( +- <font color="#CC0000"><b>651.3 μs  </b></font>)
<font color="#4E9A06"><b>pure/randomR/includeHalf/CWchar         </b></font> mean <font color="#CC0000"><b>32.77 ms  </b></font>( +- <font color="#CC0000"><b>4.030 ms  </b></font>)
<font color="#4E9A06"><b>pure/randomR/includeHalf/CSigAtomic     </b></font> mean <font color="#CC0000"><b>35.07 ms  </b></font>( +- <font color="#CC0000"><b>5.300 ms  </b></font>)
<font color="#4E9A06"><b>pure/randomR/includeHalf/CLLong         </b></font> mean <font color="#CC0000"><b>57.92 ms  </b></font>( +- <font color="#CC0000"><b>8.024 ms  </b></font>)
<font color="#4E9A06"><b>pure/randomR/includeHalf/CULLong        </b></font> mean <font color="#CC0000"><b>55.57 ms  </b></font>( +- <font color="#CC0000"><b>5.102 ms  </b></font>)
<font color="#4E9A06"><b>pure/randomR/includeHalf/CIntPtr        </b></font> mean <font color="#CC0000"><b>51.96 ms  </b></font>( +- <font color="#CC0000"><b>1.913 ms  </b></font>)
<font color="#4E9A06"><b>pure/randomR/includeHalf/CUIntPtr       </b></font> mean <font color="#CC0000"><b>50.72 ms  </b></font>( +- <font color="#CC0000"><b>1.482 ms  </b></font>)
<font color="#4E9A06"><b>pure/randomR/includeHalf/CIntMax        </b></font> mean <font color="#CC0000"><b>50.25 ms  </b></font>( +- <font color="#CC0000"><b>841.9 μs  </b></font>)
<font color="#4E9A06"><b>pure/randomR/includeHalf/CUIntMax       </b></font> mean <font color="#CC0000"><b>50.34 ms  </b></font>( +- <font color="#CC0000"><b>1.172 ms  </b></font>)
<font color="#4E9A06"><b>pure/randomR/unbounded/Float            </b></font> mean <font color="#CC0000"><b>60.17 ms  </b></font>( +- <font color="#CC0000"><b>5.086 ms  </b></font>)
<font color="#4E9A06"><b>pure/randomR/unbounded/Double           </b></font> mean <font color="#CC0000"><b>92.29 ms  </b></font>( +- <font color="#CC0000"><b>8.487 ms  </b></font>)
benchmarking pure/randomR/unbounded/Integer ... took 11.19 s, total 56 iterations
<font color="#4E9A06"><b>pure/randomR/unbounded/Integer          </b></font> mean <font color="#CC0000"><b>208.6 ms  </b></font>( +- <font color="#CC0000"><b>14.77 ms  </b></font>)</pre>