### PR TITLE
Add uniformR benchmarks

### DIFF
--- a/System/Random/Monad.hs
+++ b/System/Random/Monad.hs
@@ -126,16 +126,16 @@ import System.Random.Internal
 -- probabilistic computation as follows:
 --
 -- >>> monadicGen <- MWC.create
--- >>> rolls 10 monadicGen :: IO [Word8]
--- [2,3,6,6,4,4,3,1,5,4]
+-- >>> rolls 12 monadicGen :: IO [Word8]
+-- [4,1,2,4,4,5,2,1,5,4,6,6]
 --
 -- Given a /pure/ pseudo-random number generator, you can run it in an 'IO' or
 -- 'ST' context by first applying a monadic adapter like 'AtomicGen', 'IOGen'
 -- or 'STGen' and then running it with 'runGenM'.
 --
--- >>> let pureGen = mkStdGen 42
+-- >>> let pureGen = mkStdGen 41
 -- >>> runGenM_ (IOGen pureGen) (rolls 10) :: IO [Word8]
--- [1,1,3,2,4,5,3,4,6,2]
+-- [6,4,5,1,1,3,2,4,5,5]
 --
 -- == How to generate pseudo-random values in pure code
 --
@@ -143,9 +143,9 @@ import System.Random.Internal
 -- pseudo-random value from a monadic computation based on a pure pseudo-random
 -- number generator.
 --
--- >>> let pureGen = mkStdGen 42
+-- >>> let pureGen = mkStdGen 41
 -- >>> runGenState_ pureGen (rolls 10) :: [Word8]
--- [1,1,3,2,4,5,3,4,6,2]
+-- [6,4,5,1,1,3,2,4,5,5]
 
 -------------------------------------------------------------------------------
 -- Pseudo-random number generator interfaces

--- a/bench/Main.hs
+++ b/bench/Main.hs
@@ -19,7 +19,7 @@ import System.Random
 
 main :: IO ()
 main = do
-  let !sz = 1000000
+  let !sz = 100000
   defaultMain
     [ bgroup "baseline"
       [ let !stdGen = mkStdGen 1337 in bench "nextWord32" $ nf (genMany SM.nextWord32 stdGen) sz

--- a/bench/Main.hs
+++ b/bench/Main.hs
@@ -170,6 +170,13 @@ main = do
           , pureUniformRIncludeHalfBench @CIntMax sz
           , pureUniformRIncludeHalfBench @CUIntMax sz
           ]
+        , bgroup "unbounded"
+          [ pureUniformRBench @Float (1.23e-4, 5.67e8) sz
+          , pureUniformRBench @Double (1.23e-4, 5.67e8) sz
+          , let !i = (10 :: Integer) ^ (100 :: Integer)
+                !range = (-i - 1, i + 1)
+            in pureUniformRBench @Integer range sz
+          ]
         ]
       ]
     ]

--- a/bench/Main.hs
+++ b/bench/Main.hs
@@ -67,23 +67,143 @@ main = do
         , pureUniformBench @CIntMax sz
         , pureUniformBench @CUIntMax sz
         ]
+      , bgroup "uniformR"
+        [ bgroup "full"
+          [ pureUniformRFullBench @Word8 sz
+          , pureUniformRFullBench @Word16 sz
+          , pureUniformRFullBench @Word32 sz
+          , pureUniformRFullBench @Word64 sz
+          , pureUniformRFullBench @Word sz
+          , pureUniformRFullBench @Int8 sz
+          , pureUniformRFullBench @Int16 sz
+          , pureUniformRFullBench @Int32 sz
+          , pureUniformRFullBench @Int64 sz
+          , pureUniformRFullBench @Int sz
+          , pureUniformRFullBench @Char sz
+          , pureUniformRFullBench @Bool sz
+          , pureUniformRFullBench @CBool sz
+          , pureUniformRFullBench @CChar sz
+          , pureUniformRFullBench @CSChar sz
+          , pureUniformRFullBench @CUChar sz
+          , pureUniformRFullBench @CShort sz
+          , pureUniformRFullBench @CUShort sz
+          , pureUniformRFullBench @CInt sz
+          , pureUniformRFullBench @CUInt sz
+          , pureUniformRFullBench @CLong sz
+          , pureUniformRFullBench @CULong sz
+          , pureUniformRFullBench @CPtrdiff sz
+          , pureUniformRFullBench @CSize sz
+          , pureUniformRFullBench @CWchar sz
+          , pureUniformRFullBench @CSigAtomic sz
+          , pureUniformRFullBench @CLLong sz
+          , pureUniformRFullBench @CULLong sz
+          , pureUniformRFullBench @CIntPtr sz
+          , pureUniformRFullBench @CUIntPtr sz
+          , pureUniformRFullBench @CIntMax sz
+          , pureUniformRFullBench @CUIntMax sz
+          ]
+        , bgroup "excludeMax"
+          [ pureUniformRExcludeMaxBench @Word8 sz
+          , pureUniformRExcludeMaxBench @Word16 sz
+          , pureUniformRExcludeMaxBench @Word32 sz
+          , pureUniformRExcludeMaxBench @Word64 sz
+          , pureUniformRExcludeMaxBench @Word sz
+          , pureUniformRExcludeMaxBench @Int8 sz
+          , pureUniformRExcludeMaxBench @Int16 sz
+          , pureUniformRExcludeMaxBench @Int32 sz
+          , pureUniformRExcludeMaxBench @Int64 sz
+          , pureUniformRExcludeMaxBench @Int sz
+          , pureUniformRExcludeMaxEnumBench @Char sz
+          , pureUniformRExcludeMaxEnumBench @Bool sz
+          , pureUniformRExcludeMaxBench @CBool sz
+          , pureUniformRExcludeMaxBench @CChar sz
+          , pureUniformRExcludeMaxBench @CSChar sz
+          , pureUniformRExcludeMaxBench @CUChar sz
+          , pureUniformRExcludeMaxBench @CShort sz
+          , pureUniformRExcludeMaxBench @CUShort sz
+          , pureUniformRExcludeMaxBench @CInt sz
+          , pureUniformRExcludeMaxBench @CUInt sz
+          , pureUniformRExcludeMaxBench @CLong sz
+          , pureUniformRExcludeMaxBench @CULong sz
+          , pureUniformRExcludeMaxBench @CPtrdiff sz
+          , pureUniformRExcludeMaxBench @CSize sz
+          , pureUniformRExcludeMaxBench @CWchar sz
+          , pureUniformRExcludeMaxBench @CSigAtomic sz
+          , pureUniformRExcludeMaxBench @CLLong sz
+          , pureUniformRExcludeMaxBench @CULLong sz
+          , pureUniformRExcludeMaxBench @CIntPtr sz
+          , pureUniformRExcludeMaxBench @CUIntPtr sz
+          , pureUniformRExcludeMaxBench @CIntMax sz
+          , pureUniformRExcludeMaxBench @CUIntMax sz
+          ]
+        , bgroup "includeHalf"
+          [ pureUniformRIncludeHalfBench @Word8 sz
+          , pureUniformRIncludeHalfBench @Word16 sz
+          , pureUniformRIncludeHalfBench @Word32 sz
+          , pureUniformRIncludeHalfBench @Word64 sz
+          , pureUniformRIncludeHalfBench @Word sz
+          , pureUniformRIncludeHalfBench @Int8 sz
+          , pureUniformRIncludeHalfBench @Int16 sz
+          , pureUniformRIncludeHalfBench @Int32 sz
+          , pureUniformRIncludeHalfBench @Int64 sz
+          , pureUniformRIncludeHalfBench @Int sz
+          , pureUniformRIncludeHalfEnumBench @Char sz
+          , pureUniformRIncludeHalfEnumBench @Bool sz
+          , pureUniformRIncludeHalfBench @CBool sz
+          , pureUniformRIncludeHalfBench @CChar sz
+          , pureUniformRIncludeHalfBench @CSChar sz
+          , pureUniformRIncludeHalfBench @CUChar sz
+          , pureUniformRIncludeHalfBench @CShort sz
+          , pureUniformRIncludeHalfBench @CUShort sz
+          , pureUniformRIncludeHalfBench @CInt sz
+          , pureUniformRIncludeHalfBench @CUInt sz
+          , pureUniformRIncludeHalfBench @CLong sz
+          , pureUniformRIncludeHalfBench @CULong sz
+          , pureUniformRIncludeHalfBench @CPtrdiff sz
+          , pureUniformRIncludeHalfBench @CSize sz
+          , pureUniformRIncludeHalfBench @CWchar sz
+          , pureUniformRIncludeHalfBench @CSigAtomic sz
+          , pureUniformRIncludeHalfBench @CLLong sz
+          , pureUniformRIncludeHalfBench @CULLong sz
+          , pureUniformRIncludeHalfBench @CIntPtr sz
+          , pureUniformRIncludeHalfBench @CUIntPtr sz
+          , pureUniformRIncludeHalfBench @CIntMax sz
+          , pureUniformRIncludeHalfBench @CUIntMax sz
+          ]
+        ]
       ]
     ]
 
 pureRandomBench :: forall a. (Typeable a, Random a) => Int -> Benchmark
-pureRandomBench = let !stdGen = mkStdGen 1337 in pureBench @a (genManyRandom @a stdGen)
+pureRandomBench = let !stdGen = mkStdGen 1337 in pureBench @a (genMany (random @a) stdGen)
 
 pureUniformBench :: forall a. (Typeable a, Uniform a) => Int -> Benchmark
-pureUniformBench = let !stdGen = mkStdGen 1337 in pureBench @a (genManyUniform @a stdGen)
+pureUniformBench = let !stdGen = mkStdGen 1337 in pureBench @a (genMany (uniform @_ @a) stdGen)
+
+pureUniformRFullBench :: forall a. (Typeable a, UniformRange a, Bounded a) => Int -> Benchmark
+pureUniformRFullBench = let !range = (minBound @a, maxBound @a) in pureUniformRBench range
+
+pureUniformRExcludeMaxBench :: forall a. (Typeable a, UniformRange a, Bounded a, Num a) => Int -> Benchmark
+pureUniformRExcludeMaxBench = let !range = (minBound @a, maxBound @a - 1) in pureUniformRBench range
+
+pureUniformRExcludeMaxEnumBench :: forall a. (Typeable a, UniformRange a, Bounded a, Enum a) => Int -> Benchmark
+pureUniformRExcludeMaxEnumBench = let !range = (minBound @a, pred (maxBound @a)) in pureUniformRBench range
+
+pureUniformRIncludeHalfBench :: forall a. (Typeable a, UniformRange a, Bounded a, Integral a) => Int -> Benchmark
+pureUniformRIncludeHalfBench = let !range = (minBound @a, (maxBound @a `div` 2) + 1) in pureUniformRBench range
+
+pureUniformRIncludeHalfEnumBench :: forall a. (Typeable a, UniformRange a, Bounded a, Enum a) => Int -> Benchmark
+pureUniformRIncludeHalfEnumBench =
+  let !range = (succ (minBound @a), toEnum ((fromEnum (maxBound @a) `div` 2) + 1))
+  in pureUniformRBench range
+
+pureUniformRBench :: forall a. (Typeable a, UniformRange a) => (a, a) -> Int -> Benchmark
+pureUniformRBench range =
+  let !stdGen = mkStdGen 1337
+  in pureBench @a (genMany (flip uniformR range) stdGen)
 
 pureBench :: forall a. (Typeable a) => (Int -> ()) -> Int -> Benchmark
 pureBench f sz = bench (showsTypeRep (typeRep (Proxy :: Proxy a)) "") $ nf f sz
-
-genManyRandom :: forall a g. (Random a, RandomGen g) => g -> Int -> ()
-genManyRandom = genMany (random @a)
-
-genManyUniform :: forall a g. (Uniform a, RandomGen g) => g -> Int -> ()
-genManyUniform = genMany (uniform @g @a)
 
 genMany :: (g -> (a, g)) -> g -> Int -> ()
 genMany f g0 n = go g0 0


### PR DESCRIPTION
Adds `uniformR` benchmarks. Three different ranges are used:
- "full" uses the entire range of the `Bounded` type
- "excludeMax" uses the entire range except for `maxBound`
- "includeHalf" includes everything up to and including the halfway point

This is meant to exercise different code paths.

I've inlined a little optimisation for `Word8`, `Word16` and `Char`:

```
                                                                  BEFORE  |  AFTER
pure/uniformR/full/Word8                 mean 1.781 ms  ( +- 23.65 μs  )  |  mean 25.57 μs  ( +- 160.1 ns  )
pure/uniformR/excludeMax/Word8           mean 1.557 ms  ( +- 21.40 μs  )  |  mean 160.0 μs  ( +- 5.549 μs  )
pure/uniformR/includeHalf/Word8          mean 2.852 ms  ( +- 189.0 μs  )  |  mean 170.0 μs  ( +- 11.21 μs  )

pure/uniformR/full/Word16                mean 1.632 ms  ( +- 9.903 μs  )  |  mean 25.64 μs  ( +- 178.8 ns  )
pure/uniformR/excludeMax/Word16          mean 1.612 ms  ( +- 13.49 μs  )  |  mean 256.8 μs  ( +- 14.40 μs  )
pure/uniformR/includeHalf/Word16         mean 2.758 ms  ( +- 136.9 μs  )  |  mean 233.2 μs  ( +- 3.471 μs  )

pure/uniformR/full/Char                  mean 2.857 ms  ( +- 99.67 μs  )  |  mean 161.8 μs  ( +- 3.151 μs  )
pure/uniformR/excludeMax/Char            mean 2.766 ms  ( +- 93.39 μs  )  |  mean 182.9 μs  ( +- 2.113 μs  )
pure/uniformR/includeHalf/Char           mean 2.741 ms  ( +- 47.82 μs  )  |  mean 186.2 μs  ( +- 4.780 μs  )
```

Note that I reduced the number of iterations from 1000000 to 100000 to make the benchmarks finish faster, so the numbers here are not comparable with those in https://github.com/idontgetoutmuch/random/pull/110.