### PR TITLE
Postpone: Add MonadThrow to UniformRange

### DIFF
--- a/System/Random/Internal.hs
+++ b/System/Random/Internal.hs
@@ -56,8 +56,10 @@ module System.Random.Internal
   ) where
 
 import Control.Arrow
+import Control.Exception (throw)
 import Control.Monad.IO.Class
 import Control.Monad.ST
+import Control.Monad.Catch (MonadThrow)
 import Control.Monad.ST.Unsafe
 import Control.Monad.State.Strict
 import Data.Bits
@@ -92,7 +94,7 @@ class RandomGen g where
   -- [here](https://alexey.kuleshevi.ch/blog/2019/12/21/random-benchmarks) for
   -- more details. It is thus deprecated.
   next :: g -> (Int, g)
-  next g = runGenState g (uniformRM (genRange g))
+  next g = either throw id $ runGenStateT g (uniformRM (genRange g))
 
   -- | Returns a 'Word8' that is uniformly distributed over the entire 'Word8'
   -- range.
@@ -455,7 +457,7 @@ class UniformRange a where
   -- > uniformRM (a, b) = uniformRM (b, a)
   --
   -- @since 1.2<Paste>
-  uniformRM :: MonadRandom g s m => (a, a) -> g s -> m a
+  uniformRM :: (MonadRandom g s m, MonadThrow m) => (a, a) -> g s -> m a
 
 instance UniformRange Integer where
   uniformRM = uniformIntegerM

--- a/System/Random/Monad.hs
+++ b/System/Random/Monad.hs
@@ -118,7 +118,7 @@ import System.Random.Internal
 -- range @[1, 6]@.
 --
 -- >>> :{
--- let rolls :: MonadRandom g s m => Int -> g s -> m [Word8]
+-- let rolls :: (MonadRandom g s m, MonadThrow m) => Int -> g s -> m [Word8]
 --     rolls n = replicateM n . uniformRM (1, 6)
 -- :}
 --
@@ -144,8 +144,8 @@ import System.Random.Internal
 -- number generator.
 --
 -- >>> let pureGen = mkStdGen 41
--- >>> runGenState_ pureGen (rolls 10) :: [Word8]
--- [6,4,5,1,1,3,2,4,5,5]
+-- >>> runGenStateT_ pureGen (rolls 10) :: Maybe [Word8]
+-- Just [6,4,5,1,1,3,2,4,5,5]
 
 -------------------------------------------------------------------------------
 -- Pseudo-random number generator interfaces

--- a/bench/Main.hs
+++ b/bench/Main.hs
@@ -7,6 +7,7 @@
 
 module Main (main) where
 
+import Control.Exception (throw)
 import Data.Int
 import Data.Proxy
 import Data.Typeable
@@ -207,7 +208,7 @@ pureUniformRIncludeHalfEnumBench =
 pureUniformRBench :: forall a. (Typeable a, UniformRange a) => (a, a) -> Int -> Benchmark
 pureUniformRBench range =
   let !stdGen = mkStdGen 1337
-  in pureBench @a (genMany (uniformR range) stdGen)
+  in pureBench @a (genMany (either throw id . uniformR range) stdGen)
 
 pureBench :: forall a. (Typeable a) => (Int -> ()) -> Int -> Benchmark
 pureBench f sz = bench (showsTypeRep (typeRep (Proxy :: Proxy a)) "") $ nf f sz

--- a/random.cabal
+++ b/random.cabal
@@ -86,7 +86,8 @@ library
         base >=4.10 && <5,
         bytestring >=0.10 && <0.11,
         mtl >=2.2 && <2.3,
-        splitmix >=0.0.3 && <0.1
+        splitmix >=0.0.3 && <0.1,
+        exceptions
 
 test-suite legacy-test
     type:             exitcode-stdio-1.0

--- a/test/Spec/Range.hs
+++ b/test/Spec/Range.hs
@@ -6,6 +6,7 @@ module Spec.Range
   , uniformRangeWithinExcluded
   ) where
 
+import Control.Exception (throw)
 import System.Random.Monad
 
 symmetric :: (RandomGen g, Random a, Eq a) => g -> (a, a) -> Bool
@@ -25,10 +26,10 @@ singleton g x = result == x
 
 uniformRangeWithin :: (RandomGen g, UniformRange a, Ord a) => g -> (a, a) -> Bool
 uniformRangeWithin gen (l, r) =
-  runGenState_ gen $ \g ->
+  either throw id $ runGenStateT_ gen $ \g ->
     (\result -> min l r <= result && result <= max l r) <$> uniformRM (l, r) g
 
 uniformRangeWithinExcluded :: (RandomGen g, UniformRange a, Ord a) => g -> (a, a) -> Bool
 uniformRangeWithinExcluded gen (l, r) =
-  runGenState_ gen $ \g ->
+  either throw id $ runGenStateT_ gen $ \g ->
     (\result -> min l r <= result && (l == r || result < max l r)) <$> uniformRM (l, r) g


### PR DESCRIPTION
For now `uniformRM` doesn't fail any where, this PR just prepares the types for failure