### PR TITLE
Refactor mutable generators

### DIFF
--- a/System/Random.hs
+++ b/System/Random.hs
@@ -101,7 +101,7 @@ import qualified System.Random.SplitMix as SM
 --     rollsM n = replicateM n . uniformRM (1, 6)
 --     pureGen = mkStdGen 137
 -- in
---     runGenState_ pureGen (rollsM 10) :: [Word8]
+--     runStateGen_ pureGen (rollsM 10) :: [Word8]
 -- :}
 -- [1,2,6,6,5,1,4,6,5,4]
 
@@ -134,7 +134,7 @@ import qualified System.Random.SplitMix as SM
 --
 -- @since 1.2
 uniform :: (RandomGen g, Uniform a) => g -> (a, g)
-uniform g = runGenState g uniformM
+uniform g = runStateGen g uniformM
 
 -- | Generates a value uniformly distributed over the provided range, which
 -- is interpreted as inclusive in the lower and upper bound.
@@ -153,14 +153,14 @@ uniform g = runGenState g uniformM
 --
 -- @since 1.2
 uniformR :: (RandomGen g, UniformRange a) => (a, a) -> g -> (a, g)
-uniformR r g = runGenState g (uniformRM r)
+uniformR r g = runStateGen g (uniformRM r)
 
 -- | Generates a 'ByteString' of the specified size using a pure pseudo-random
 -- number generator. See 'uniformByteString' for the monadic version.
 --
 -- @since 1.2
 genByteString :: RandomGen g => Int -> g -> (ByteString, g)
-genByteString n g = runPureGenST g (uniformByteString n)
+genByteString n g = runStateGenST g (uniformByteString n)
 {-# INLINE genByteString #-}
 
 -- | The class of types for which uniformly distributed values can be
@@ -180,7 +180,7 @@ class Random a where
   {-# INLINE randomR #-}
   randomR :: RandomGen g => (a, a) -> g -> (a, g)
   default randomR :: (RandomGen g, UniformRange a) => (a, a) -> g -> (a, g)
-  randomR r g = runGenState g (uniformRM r)
+  randomR r g = runStateGen g (uniformRM r)
 
   -- | The same as 'randomR', but using a default range determined by the type:
   --
@@ -194,7 +194,7 @@ class Random a where
   {-# INLINE random #-}
   random  :: RandomGen g => g -> (a, g)
   default random :: (RandomGen g, Uniform a) => g -> (a, g)
-  random g = runGenState g uniformM
+  random g = runStateGen g uniformM
 
   -- | Plural variant of 'randomR', producing an infinite list of
   -- pseudo-random values instead of returning a new generator.
@@ -264,11 +264,11 @@ instance Random CDouble where
 instance Random Char
 instance Random Bool
 instance Random Double where
-  randomR r g = runGenState g (uniformRM r)
-  random g = runGenState g (uniformRM (0, 1))
+  randomR r g = runStateGen g (uniformRM r)
+  random g = runStateGen g (uniformRM (0, 1))
 instance Random Float where
-  randomR r g = runGenState g (uniformRM r)
-  random g = runGenState g (uniformRM (0, 1))
+  randomR r g = runStateGen g (uniformRM r)
+  random g = runStateGen g (uniformRM (0, 1))
 
 -------------------------------------------------------------------------------
 -- Global pseudo-random number generator

--- a/stack-old.yaml
+++ b/stack-old.yaml
@@ -51,10 +51,8 @@ extra-deps:
   # implement 'Prim'. So far, this is only the case on lehin's fork, so we use
   # that.
 - splitmix-0.0.4@sha256:fb9bb8b54a2e76c8a021fe5c4c3798047e1f60e168379a1f80693047fe00ad0e,4813
-  # Not contained in all snapshots we want to test against
 - doctest-0.16.2@sha256:2f96e9bbe9aee11b47453c82c24b3dc76cdbb8a2a7c984dfd60b4906d08adf68,6942
 - cabal-doctest-1.0.8@sha256:34dff6369d417df2699af4e15f06bc181d495eca9c51efde173deae2053c197c,1491
-- primitive-0.6.4.0@sha256:5b6a2c3cc70a35aabd4565fcb9bb1dd78fe2814a36e62428a9a1aae8c32441a1,2079
 
 # Override default flag values for local packages and extra-deps
 flags:

--- a/test/Spec/Range.hs
+++ b/test/Spec/Range.hs
@@ -25,10 +25,10 @@ singleton g x = result == x
 
 uniformRangeWithin :: (RandomGen g, UniformRange a, Ord a) => g -> (a, a) -> Bool
 uniformRangeWithin gen (l, r) =
-  runGenState_ gen $ \g ->
+  runStateGen_ gen $ \g ->
     (\result -> min l r <= result && result <= max l r) <$> uniformRM (l, r) g
 
 uniformRangeWithinExcluded :: (RandomGen g, UniformRange a, Ord a) => g -> (a, a) -> Bool
 uniformRangeWithinExcluded gen (l, r) =
-  runGenState_ gen $ \g ->
+  runStateGen_ gen $ \g ->
     (\result -> min l r <= result && (l == r || result < max l r)) <$> uniformRM (l, r) g

--- a/test/Spec/Run.hs
+++ b/test/Spec/Run.hs
@@ -5,7 +5,7 @@ import System.Random.Monad
 
 runsEqual :: RandomGen g => g -> IO Bool
 runsEqual g = do
-  let pureResult = runGenState_ g uniformM :: Word64
+  let pureResult = runStateGen_ g uniformM :: Word64
       stResult = runSTGen_ g uniformM
   ioResult <- runGenM_ (IOGen g) uniformM
   atomicResult <- runGenM_ (AtomicGen g) uniformM


### PR DESCRIPTION
Main semantic change in this PR is the switch to `TypeFamilyDependencies` for `Frozen`, which until couple days ago I mistakenly thought can only be used with closed type families:
```haskell
type Frozen g = (f :: *) | f -> g
```

This approach gives very nice usability improvements:
* stateful random libraries like `mwc-random` do not have to define any newtypes (see the updated haddock), thus simplifying corresponding instances and overall making usage of `MonadRandom` more pleasant. I am sure @Shimuuar will approve of this approach
* `STGen` , `IOGen` ... now get a standalone pure counterpart, which now have a constructor that is easily discoverable in haddock. With `data family Frozen`, instead of `type family Frozen` constructor is hidden from the user and can't really be documented directly

Besides semantic changes it contains some improvement to consistent naming. Each Monadic generator has now a suffix `M`, ie. `IOGenM`. Each monadic has a pure counterpart without `M`, ie. `IOGen`

`PureGen` is now renamed `StateGen`, which I think better describes its nature and how it works underneath

The important part of this PR is that everything else works just the same as before with respect to performance and type inference (without `TypeFamilyDependencies` `Frozen` would make types of some functions ambiguous and would drastically impact the usability, which was my main concern before and the reason for rejection of #67 )