### PR TITLE
Add 'instance UniformRange Natural'

### DIFF
--- a/bench/Main.hs
+++ b/bench/Main.hs
@@ -13,6 +13,7 @@ import Data.Typeable
 import Data.Word
 import Foreign.C.Types
 import Gauge.Main
+import Numeric.Natural (Natural)
 import System.Random.SplitMix as SM
 
 import System.Random
@@ -176,6 +177,9 @@ main = do
           , let !i = (10 :: Integer) ^ (100 :: Integer)
                 !range = (-i - 1, i + 1)
             in pureUniformRBench @Integer range sz
+          , let !n = (10 :: Natural) ^ (100 :: Natural)
+                !range = (1, n - 1)
+            in pureUniformRBench @Natural range sz
           ]
         ]
       ]

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -9,15 +9,16 @@
 module Main (main) where
 
 import Data.Coerce
-import Data.Word
 import Data.Int
+import Data.Typeable
+import Data.Word
+import Foreign.C.Types
+import Numeric.Natural (Natural)
 import System.Random
+import Test.SmallCheck.Series as SC
 import Test.Tasty
 import Test.Tasty.HUnit
 import Test.Tasty.SmallCheck as SC
-import Test.SmallCheck.Series as SC
-import Data.Typeable
-import Foreign.C.Types
 
 #include "HsBaseConfig.h"
 
@@ -66,6 +67,7 @@ main =
     , integralSpec @CIntMax
     , integralSpec @CUIntMax
     , integralSpec @Integer
+    , integralSpec @Natural
     -- , bitmaskSpec @Word8
     -- , bitmaskSpec @Word16
     -- , bitmaskSpec @Word32
@@ -103,7 +105,7 @@ showsType = showsTypeRep (typeRep (Proxy :: Proxy t))
 
 rangeSpec ::
      forall a.
-     (SC.Serial IO a, Typeable a, Ord a, Random a, UniformRange a, Show a)
+     (SC.Serial IO a, Typeable a, Ord a, UniformRange a, Show a)
   => TestTree
 rangeSpec =
   testGroup ("Range (" ++ showsType @a ")")
@@ -112,7 +114,7 @@ rangeSpec =
 
 integralSpec ::
      forall a.
-     (SC.Serial IO a, Typeable a, Ord a, Random a, UniformRange a, Show a)
+     (SC.Serial IO a, Typeable a, Ord a, UniformRange a, Show a)
   => TestTree
 integralSpec  =
   testGroup ("(" ++ showsType @a ")")

--- a/test/Spec/Range.hs
+++ b/test/Spec/Range.hs
@@ -8,20 +8,20 @@ module Spec.Range
 
 import System.Random.Monad
 
-symmetric :: (RandomGen g, Random a, Eq a) => g -> (a, a) -> Bool
-symmetric g (l, r) = fst (randomR (l, r) g) == fst (randomR (r, l) g)
+symmetric :: (RandomGen g, UniformRange a, Eq a) => g -> (a, a) -> Bool
+symmetric g (l, r) = fst (uniformR (l, r) g) == fst (uniformR (r, l) g)
 
-bounded :: (RandomGen g, Random a, Ord a) => g -> (a, a) -> Bool
+bounded :: (RandomGen g, UniformRange a, Ord a) => g -> (a, a) -> Bool
 bounded g (l, r) = bottom <= result && result <= top
   where
     bottom = min l r
     top = max l r
-    result = fst (randomR (l, r) g)
+    result = fst (uniformR (l, r) g)
 
-singleton :: (RandomGen g, Random a, Eq a) => g -> a -> Bool
+singleton :: (RandomGen g, UniformRange a, Eq a) => g -> a -> Bool
 singleton g x = result == x
   where
-    result = fst (randomR (x, x) g)
+    result = fst (uniformR (x, x) g)
 
 uniformRangeWithin :: (RandomGen g, UniformRange a, Ord a) => g -> (a, a) -> Bool
 uniformRangeWithin gen (l, r) =


### PR DESCRIPTION
The main addition here is to add `instance UniformRange Natural`, also see https://github.com/haskell/random/issues/44.

To do this, I changed the `Integer`-specific `uniformIntegerM` to a generic `uniformIntegralM`. Since this function was and is recursive, I changed the pragma from `INLINE` to `INLINEABLE`.

I made sure that these more generic functions are no slower than before. Note that `random/Integer` benchmarks small ranges, for which a fast path is triggered; `uniformR/unbounded/Integer` and the new `uniformR/unbounded/Natural` benchmark very large ranges where there is no fast path.

Before (9ee79a7):
```
pure/random/Integer                      mean 362.6 μs  ( +- 44.38 μs  )
pure/uniformR/unbounded/Integer          mean 189.3 ms  ( +- 8.531 ms  )
```

After (this PR):
```
pure/random/Integer                      mean 369.0 μs  ( +- 36.89 μs  )
pure/uniformR/unbounded/Integer          mean 122.8 ms  ( +- 6.044 ms  )
pure/uniformR/unbounded/Natural          mean 110.6 ms  ( +- 16.08 ms  )
```

Other changes:
- specs use `uniformR` instead of `randomR`; this allow us to make the constraints more precise
- added `Natural` benchmark and specs
- sorted some imports alphabetically