### PR TITLE
Repo lives at https://github.com/haskell/random.git

### DIFF
--- a/random.cabal
+++ b/random.cabal
@@ -66,7 +66,7 @@ extra-source-files:
 
 source-repository head
     type:     git
-    location: http://git.haskell.org/packages/random.git
+    location: https://github.com/haskell/random.git
 
 custom-setup
     setup-depends:


### PR DESCRIPTION
... http://git.haskell.org/packages/random.git no longer exists.