### PR TITLE
Respond to community feedback

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,15 +42,15 @@ jobs:
   include:
   # We grab the appropriate GHC and cabal-install versions from hvr's PPA. See:
   # https://github.com/hvr/multi-ghc-travis
-  - env: BUILD=stack ARGS="--resolver lts-11.22 --stack-yaml stack-old.yaml"
+  - env: BUILD=stack ARGS="--resolver lts-11.22" STACK_YAML="--stack-yaml stack-old.yaml"
     compiler: ": #stack 8.2.2"
     addons: {apt: {packages: [libgmp-dev]}}
 
-  - env: BUILD=stack ARGS="--resolver lts-12.26 --stack-yaml stack-old.yaml"
+  - env: BUILD=stack ARGS="--resolver lts-12.26" STACK_YAML="--stack-yaml stack-old.yaml"
     compiler: ": #stack 8.4.4"
     addons: {apt: {packages: [libgmp-dev]}}
 
-  - env: BUILD=stack ARGS="--resolver lts-14.27" COVERALLS_STACK_YAML="stack-coveralls.yaml"
+  - env: BUILD=stack ARGS="--resolver lts-14.27" STACK_YAML="--stack-yaml stack-old.yaml" COVERALLS_STACK_YAML="stack-coveralls.yaml"
     compiler: ": #stack 8.6.5"
     addons: {apt: {packages: [libgmp-dev]}}
 
@@ -137,7 +137,7 @@ script:
          travis_retry curl -L https://github.com/lehins/stack-hpc-coveralls/releases/download/0.0.5.0/shc.tar.gz | tar xz shc
          STACK_YAML="$COVERALLS_STACK_YAML" ./shc --repo-token=$COVERALLS_REPO_TOKEN combined custom
       else
-         stack --no-terminal $ARGS test $BUILD_ARGS
+         stack --no-terminal $ARGS $STACK_YAML test $BUILD_ARGS
       fi
       ;;
     cabal)

--- a/bench/Main.hs
+++ b/bench/Main.hs
@@ -17,7 +17,7 @@ import Gauge.Main
 import Numeric.Natural (Natural)
 import System.Random.SplitMix as SM
 
-import System.Random.Monad
+import System.Random.Stateful
 
 main :: IO ()
 main = do

--- a/random.cabal
+++ b/random.cabal
@@ -37,21 +37,21 @@ description:
     As an example, here is how you can simulate rolls of a six-sided die using
     'System.Random.Stateful.uniformRM':
     .
-    >>> let rollM = uniformRM (1, 6)                 :: MonadRandom g s m => g s -> m Word8
+    >>> let rollM = uniformRM (1, 6)                 :: StatefulGen g s m => g s -> m Word8
     >>> let pureGen = mkStdGen 42
     >>> runGenState_ pureGen (replicateM 10 . rollM) :: m [Word8]
     [1,1,3,2,4,5,3,4,6,2]
     .
     The monadic adapter 'System.Random.Stateful.runGenState_' is used here to lift
     the pure pseudo-random number generator @pureGen@ into the
-    'System.Random.Stateful.MonadRandom' context.
+    'System.Random.Stateful.StatefulGen' context.
     .
     The monadic interface can also be used with existing monadic pseudo-random
     number generators. In this example, we use the one provided in the
     <https://hackage.haskell.org/package/mwc-random mwc-random> package:
     .
     >>> import System.Random.MWC as MWC
-    >>> let rollM = uniformRM (1, 6)       :: MonadRandom g s m => g s -> m Word8
+    >>> let rollM = uniformRM (1, 6)       :: StatefulGen g s m => g s -> m Word8
     >>> monadicGen <- MWC.create
     >>> (replicateM 10 . rollM) monadicGen :: m [Word8]
     [2,3,6,6,4,4,3,1,5,4]
@@ -82,17 +82,16 @@ library
 
     hs-source-dirs:   src
     default-language: Haskell2010
-    ghc-options:
-        -Weverything -Wno-implicit-prelude -Wno-missing-import-lists
-        -Wno-missing-local-signatures -Wno-redundant-constraints
-        -Wno-unsafe
+    ghc-options: -Wall
+                 -Wincomplete-record-updates
+                 -Wincomplete-uni-patterns
 
     build-depends:
         base >=4.10 && <5,
-        bytestring >=0.10 && <0.11,
+        bytestring >=0.10.4 && <0.11,
         deepseq >=1.1 && <2,
         mtl >=2.2 && <2.3,
-        splitmix >=0.0.3 && <0.1
+        splitmix >=0.1 && <0.2
 
 test-suite legacy-test
     type:             exitcode-stdio-1.0
@@ -108,7 +107,7 @@ test-suite legacy-test
     default-language: Haskell2010
     ghc-options:      -with-rtsopts=-M4M -Wno-deprecations
     build-depends:
-        base >=4.10 && <5,
+        base -any,
         containers >=0.5 && <0.7,
         random -any
 
@@ -118,7 +117,7 @@ test-suite doctests
     hs-source-dirs:   test
     default-language: Haskell2010
     build-depends:
-        base >=4.10 && <5,
+        base -any,
         doctest >=0.15 && <0.17,
         mwc-random >=0.13 && <0.15,
         primitive >=0.6 && <0.8,
@@ -136,8 +135,8 @@ test-suite spec
     default-language: Haskell2010
     ghc-options:      -Wall
     build-depends:
-        base >=4.10 && <5,
-        bytestring >=0.10 && <0.11,
+        base -any,
+        bytestring -any,
         random -any,
         smallcheck >=1.1 && <1.2,
         tasty >=1.0 && <1.3,
@@ -155,7 +154,7 @@ benchmark legacy-bench
         -Wall -O2 -threaded -rtsopts -with-rtsopts=-N -Wno-deprecations
 
     build-depends:
-        base >=4.10 && <5,
+        base -any,
         random -any,
         rdtsc -any,
         split >=0.2 && <0.3,
@@ -168,7 +167,7 @@ benchmark bench
     default-language: Haskell2010
     ghc-options:      -Wall -O2
     build-depends:
-        base >=4.10 && <5,
+        base -any,
         gauge >=0.2.3 && <0.3,
         random -any,
-        splitmix >=0.0.3 && <0.1
+        splitmix >=0.1 && <0.2

--- a/random.cabal
+++ b/random.cabal
@@ -27,24 +27,24 @@ description:
     .
     See "System.Random" for more details.
     .
-    == "System.Random.Monad": monadic pseudo-random number interface
+    == "System.Random.Stateful": monadic pseudo-random number interface
     .
-    In monadic code, use 'System.Random.Monad.uniformM' and
-    'System.Random.Monad.uniformRM' from "System.Random.Monad" to generate
+    In monadic code, use 'System.Random.Stateful.uniformM' and
+    'System.Random.Stateful.uniformRM' from "System.Random.Stateful" to generate
     pseudo-random numbers with a monadic pseudo-random number generator, or
     using a monadic adapter.
     .
     As an example, here is how you can simulate rolls of a six-sided die using
-    'System.Random.Monad.uniformRM':
+    'System.Random.Stateful.uniformRM':
     .
     >>> let rollM = uniformRM (1, 6)                 :: MonadRandom g s m => g s -> m Word8
     >>> let pureGen = mkStdGen 42
     >>> runGenState_ pureGen (replicateM 10 . rollM) :: m [Word8]
     [1,1,3,2,4,5,3,4,6,2]
     .
-    The monadic adapter 'System.Random.Monad.runGenState_' is used here to lift
+    The monadic adapter 'System.Random.Stateful.runGenState_' is used here to lift
     the pure pseudo-random number generator @pureGen@ into the
-    'System.Random.Monad.MonadRandom' context.
+    'System.Random.Stateful.MonadRandom' context.
     .
     The monadic interface can also be used with existing monadic pseudo-random
     number generators. In this example, we use the one provided in the
@@ -56,7 +56,7 @@ description:
     >>> (replicateM 10 . rollM) monadicGen :: m [Word8]
     [2,3,6,6,4,4,3,1,5,4]
     .
-    See "System.Random.Monad" for more details.
+    See "System.Random.Stateful" for more details.
 
 category:           System
 build-type:         Custom
@@ -78,7 +78,7 @@ library
     exposed-modules:
         System.Random
         System.Random.Internal
-        System.Random.Monad
+        System.Random.Stateful
 
     hs-source-dirs:   src
     default-language: Haskell2010

--- a/random.cabal
+++ b/random.cabal
@@ -82,9 +82,8 @@ library
 
     hs-source-dirs:   src
     default-language: Haskell2010
-    ghc-options: -Wall
-                 -Wincomplete-record-updates
-                 -Wincomplete-uni-patterns
+    ghc-options:
+        -Wall -Wincomplete-record-updates -Wincomplete-uni-patterns
 
     build-depends:
         base >=4.10 && <5,

--- a/src/System/Random.hs
+++ b/src/System/Random.hs
@@ -97,7 +97,7 @@ import qualified System.Random.SplitMix as SM
 -- pseudo-random number generator, use 'runGenState' and its variants.
 --
 -- >>> :{
--- let rollsM :: MonadRandom g m => Int -> g -> m [Word8]
+-- let rollsM :: StatefulGen g m => Int -> g -> m [Word8]
 --     rollsM n = replicateM n . uniformRM (1, 6)
 --     pureGen = mkStdGen 137
 -- in
@@ -123,14 +123,14 @@ import qualified System.Random.SplitMix as SM
 --     produced by the two resulting generators are not correlated. See [1] for
 --     some background on splittable pseudo-random generators.
 --
--- ['System.Random.Monad.MonadRandom': monadic pseudo-random number generators]
---     See "System.Random.Monad" module
+-- ['System.Random.Stateful.StatefulGen': monadic pseudo-random number generators]
+--     See "System.Random.Stateful" module
 --
 
 -- | Generates a value uniformly distributed over all possible values of that
 -- type.
 --
--- This is a pure version of 'System.Random.Monad.uniformM'.
+-- This is a pure version of 'System.Random.Stateful.uniformM'.
 --
 -- @since 1.2
 uniform :: (RandomGen g, Uniform a) => g -> (a, g)
@@ -149,7 +149,7 @@ uniform g = runStateGen g uniformM
 --
 -- > uniformR (a, b) = uniformR (b, a)
 --
--- This is a pure version of 'System.Random.Monad.uniformRM'.
+-- This is a pure version of 'System.Random.Stateful.uniformRM'.
 --
 -- @since 1.2
 uniformR :: (RandomGen g, UniformRange a) => (a, a) -> g -> (a, g)

--- a/src/System/Random.hs
+++ b/src/System/Random.hs
@@ -97,7 +97,7 @@ import qualified System.Random.SplitMix as SM
 -- pseudo-random number generator, use 'runGenState' and its variants.
 --
 -- >>> :{
--- let rollsM :: MonadRandom g s m => Int -> g s -> m [Word8]
+-- let rollsM :: MonadRandom g m => Int -> g -> m [Word8]
 --     rollsM n = replicateM n . uniformRM (1, 6)
 --     pureGen = mkStdGen 137
 -- in

--- a/src/System/Random/Internal.hs
+++ b/src/System/Random/Internal.hs
@@ -245,7 +245,8 @@ class Monad m => StatefulGen g m where
 
 
 
--- | This class is designed for stateful RNGs that can be saved as immutable data type.
+-- | This class is designed for stateful pseudo-random number generators that
+-- can be saved as and restored from an immutable data type.
 --
 -- @since 1.2
 class StatefulGen (MutableGen f m) m => FrozenGen f m where

--- a/src/System/Random/Internal.hs
+++ b/src/System/Random/Internal.hs
@@ -259,7 +259,7 @@ class StatefulGen (MutableGen f m) m => FrozenGen f m where
   --
   -- @since 1.2
   freezeGen :: MutableGen f m -> m f
-  -- | Restores the pseudo-random number generator from its frozen 'Seed'.
+  -- | Restores the pseudo-random number generator from its frozen seed.
   --
   -- @since 1.2
   thawGen :: f -> m (MutableGen f m)

--- a/src/System/Random/Internal.hs
+++ b/src/System/Random/Internal.hs
@@ -255,7 +255,7 @@ class StatefulGen (MutableGen f m) m => FrozenGen f m where
   --
   -- @since 1.2
   type MutableGen f m = (g :: Type) | g -> f
-  -- | Saves the state of the pseudo-random number generator as a frozen 'Seed'.
+  -- | Saves the state of the pseudo-random number generator as a frozen seed.
   --
   -- @since 1.2
   freezeGen :: MutableGen f m -> m f

--- a/src/System/Random/Internal.hs
+++ b/src/System/Random/Internal.hs
@@ -175,6 +175,7 @@ class RandomGen g where
 
 -- | 'StatefulGen' is an interface to monadic pseudo-random number generators.
 class Monad m => StatefulGen g m where
+  {-# MINIMAL (uniformWord32|uniformWord64) #-}
   -- | @uniformWord32R upperBound g@ generates a 'Word32' that is uniformly
   -- distributed over the range @[0, upperBound]@.
   --

--- a/src/System/Random/Monad.hs
+++ b/src/System/Random/Monad.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE Safe #-}
@@ -28,8 +29,6 @@ module System.Random.Monad
   -- * Pure and monadic pseudo-random number generator interfaces
   -- $interfaces
   , MonadRandom(..)
-  , runGenM
-  , runGenM_
   , RandomGenM(..)
   , randomM
   , randomRM
@@ -39,7 +38,6 @@ module System.Random.Monad
   -- $monadicadapters
 
   -- ** Pure adapter
-  , StateGen(..)
   , StateGenM(..)
   , runStateGen
   , runStateGen_
@@ -47,16 +45,16 @@ module System.Random.Monad
   , runStateGenT_
   , runStateGenST
   -- ** Mutable adapter with atomic operations
-  , AtomicGen(..)
   , AtomicGenM(..)
+  , newAtomicGenM
   , applyAtomicGen
   -- ** Mutable adapter in 'IO'
-  , IOGen(..)
   , IOGenM(..)
+  , newIOGenM
   , applyIOGen
   -- ** Mutable adapter in 'ST'
-  , STGen(..)
   , STGenM(..)
+  , newSTGenM
   , applySTGen
   , runSTGen
   , runSTGen_
@@ -124,7 +122,7 @@ import System.Random.Internal
 -- number generator, you can run this probabilistic computation as follows:
 --
 -- >>> :{
--- let rollsM :: MonadRandom g s m => Int -> g s -> m [Word8]
+-- let rollsM :: MonadRandom g m => Int -> g -> m [Word8]
 --     rollsM n = replicateM n . uniformRM (1, 6)
 -- in do
 --     monadicGen <- MWC.create
@@ -134,16 +132,16 @@ import System.Random.Internal
 --
 -- Given a /pure/ pseudo-random number generator, you can run the monadic
 -- pseudo-random number computation @rollsM@ in an 'IO' or 'ST' context by
--- first applying a monadic adapter like 'AtomicGen', 'IOGen' or 'STGen'
+-- applying a monadic adapter like 'AtomicGenM', 'IOGenM' or 'STGenM'
 -- (see [monadic-adapters](#monadicadapters)) to the pure pseudo-random number
--- generator and then running it with 'runGenM'.
+-- generator.
 --
 -- >>> :{
--- let rollsM :: MonadRandom g s m => Int -> g s -> m [Word8]
+-- let rollsM :: MonadRandom g m => Int -> g -> m [Word8]
 --     rollsM n = replicateM n . uniformRM (1, 6)
 --     pureGen = mkStdGen 42
 -- in
---     runGenM_ (IOGen pureGen) (rollsM 10) :: IO [Word8]
+--     newIOGenM pureGen >>= rollsM 10 :: IO [Word8]
 -- :}
 -- [5,1,4,3,3,2,5,2,2,4]
 
@@ -190,64 +188,44 @@ import System.Random.Internal
 -- | Interface to operations on 'RandomGen' wrappers like 'IOGenM' and 'StateGenM'.
 --
 -- @since 1.2
-class (RandomGen r, MonadRandom (g r) s m) => RandomGenM g r s m where
-  applyRandomGenM :: (r -> (a, r)) -> g r s -> m a
+class (RandomGen r, MonadRandom g m) => RandomGenM g r m | g -> r where
+  applyRandomGenM :: (r -> (a, r)) -> g -> m a
 
 -- | Splits a pseudo-random number generator into two. Overwrites the mutable
 -- wrapper with one of the resulting generators and returns the other.
 --
 -- @since 1.2
-splitGenM :: RandomGenM g r s m => g r s -> m r
+splitGenM :: RandomGenM g r m => g -> m r
 splitGenM = applyRandomGenM split
 
-instance (RandomGen r, MonadIO m) => RandomGenM IOGenM r RealWorld m where
+instance (RandomGen r, MonadIO m) => RandomGenM (IOGenM r) r m where
   applyRandomGenM = applyIOGen
 
-instance (RandomGen r, MonadIO m) => RandomGenM AtomicGenM r RealWorld m where
+instance (RandomGen r, MonadIO m) => RandomGenM (AtomicGenM r) r m where
   applyRandomGenM = applyAtomicGen
 
-instance (RandomGen r, MonadState r m) => RandomGenM StateGenM r r m where
+instance (RandomGen r, MonadState r m) => RandomGenM (StateGenM r) r m where
   applyRandomGenM f _ = state f
 
-instance RandomGen r => RandomGenM STGenM r s (ST s) where
+instance RandomGen r => RandomGenM (STGenM r s) r (ST s) where
   applyRandomGenM = applySTGen
-
--- | Runs a mutable pseudo-random number generator from its 'Frozen' state.
---
--- >>> import Data.Int (Int8)
--- >>> runGenM (IOGen (mkStdGen 217)) (`uniformListM` 5) :: IO ([Int8], IOGen StdGen)
--- ([-74,37,-50,-2,3],IOGen {unIOGen = StdGen {unStdGen = SMGen 4273268533320920145 15251669095119325999}})
---
--- @since 1.2
-runGenM :: MonadRandom g s m => Frozen g -> (g s -> m a) -> m (a, Frozen g)
-runGenM fg action = do
-  g <- thawGen fg
-  res <- action g
-  fg' <- freezeGen g
-  pure (res, fg')
-
--- | Same as 'runGenM', but only returns the generated value.
---
--- @since 1.2
-runGenM_ :: MonadRandom g s m => Frozen g -> (g s -> m a) -> m a
-runGenM_ fg action = fst <$> runGenM fg action
 
 -- | Generates a list of pseudo-random values.
 --
 -- @since 1.2
-uniformListM :: (MonadRandom g s m, Uniform a) => g s -> Int -> m [a]
+uniformListM :: (MonadRandom g m, Uniform a) => g -> Int -> m [a]
 uniformListM gen n = replicateM n (uniformM gen)
 
 -- | Generates a pseudo-random value using monadic interface and `Random` instance.
 --
 -- @since 1.2
-randomM :: (RandomGenM g r s m, Random a) => g r s -> m a
+randomM :: (RandomGenM g r m, Random a) => g -> m a
 randomM = applyRandomGenM random
 
 -- | Generates a pseudo-random value using monadic interface and `Random` instance.
 --
 -- @since 1.2
-randomRM :: (RandomGenM g r s m, Random a) => (a, a) -> g r s -> m a
+randomRM :: (RandomGenM g r m, Random a) => (a, a) -> g -> m a
 randomRM r = applyRandomGenM (randomR r)
 
 -- | Wraps an 'IORef' that holds a pure pseudo-random number generator. All
@@ -258,15 +236,12 @@ randomRM r = applyRandomGenM (randomR r)
 --     of its atomic operations.
 --
 -- @since 1.2
-newtype AtomicGenM g s = AtomicGenM { unAtomicGenM :: IORef g}
+newtype AtomicGenM g = AtomicGenM { unAtomicGenM :: IORef g}
 
-newtype AtomicGen g = AtomicGen { unAtomicGen :: g }
-    deriving stock (Eq, Show, Read)
+newAtomicGenM :: MonadIO m => g -> m (AtomicGenM g)
+newAtomicGenM = fmap AtomicGenM . liftIO . newIORef
 
-instance (RandomGen g, MonadIO m) => MonadRandom (AtomicGenM g) RealWorld m where
-  type Frozen (AtomicGenM g) = AtomicGen g
-  thawGen (AtomicGen g) = fmap AtomicGenM (liftIO $ newIORef g)
-  freezeGen (AtomicGenM gVar) = fmap AtomicGen (liftIO $ readIORef gVar)
+instance (RandomGen g, MonadIO m) => MonadRandom (AtomicGenM g) m where
   uniformWord32R r = applyAtomicGen (genWord32R r)
   {-# INLINE uniformWord32R #-}
   uniformWord64R r = applyAtomicGen (genWord64R r)
@@ -285,7 +260,7 @@ instance (RandomGen g, MonadIO m) => MonadRandom (AtomicGenM g) RealWorld m wher
 -- generator.
 --
 -- @since 1.2
-applyAtomicGen :: MonadIO m => (g -> (a, g)) -> AtomicGenM g RealWorld -> m a
+applyAtomicGen :: MonadIO m => (g -> (a, g)) -> (AtomicGenM g) -> m a
 applyAtomicGen op (AtomicGenM gVar) =
   liftIO $ atomicModifyIORef' gVar $ \g ->
     case op g of
@@ -307,18 +282,15 @@ applyAtomicGen op (AtomicGenM gVar) =
 --
 -- and then run it:
 --
--- >>> runGenM_ (IOGen (mkStdGen 1729)) ioGen
+-- >>> newIOGenM (mkStdGen 1729) >>= ioGen
 --
 -- @since 1.2
-newtype IOGenM g s = IOGenM { unIOGenM :: IORef g }
+newtype IOGenM g = IOGenM { unIOGenM :: IORef g }
 
-newtype IOGen g = IOGen { unIOGen :: g }
-    deriving stock (Eq, Show, Read)
+newIOGenM :: MonadIO m => g -> m (IOGenM g)
+newIOGenM = fmap IOGenM . liftIO . newIORef
 
-instance (RandomGen g, MonadIO m) => MonadRandom (IOGenM g) RealWorld m where
-  type Frozen (IOGenM g) = IOGen g
-  thawGen (IOGen g) = fmap IOGenM (liftIO $ newIORef g)
-  freezeGen (IOGenM gVar) = fmap IOGen (liftIO $ readIORef gVar)
+instance (RandomGen g, MonadIO m) => MonadRandom (IOGenM g) m where
   uniformWord32R r = applyIOGen (genWord32R r)
   {-# INLINE uniformWord32R #-}
   uniformWord64R r = applyIOGen (genWord64R r)
@@ -336,7 +308,7 @@ instance (RandomGen g, MonadIO m) => MonadRandom (IOGenM g) RealWorld m where
 -- | Applies a pure operation to the wrapped pseudo-random number generator.
 --
 -- @since 1.2
-applyIOGen :: MonadIO m => (g -> (a, g)) -> IOGenM g RealWorld -> m a
+applyIOGen :: MonadIO m => (g -> (a, g)) -> IOGenM g -> m a
 applyIOGen f (IOGenM ref) = liftIO $ do
   g <- readIORef ref
   case f g of
@@ -351,13 +323,11 @@ applyIOGen f (IOGenM ref) = liftIO $ do
 -- @since 1.2
 newtype STGenM g s = STGenM { unSTGenM :: STRef s g }
 
-newtype STGen g = STGen { unSTGen :: g }
-    deriving stock (Eq, Show, Read)
+newSTGenM :: g -> ST s (STGenM g s)
+newSTGenM = fmap STGenM . newSTRef
 
-instance RandomGen g => MonadRandom (STGenM g) s (ST s) where
-  type Frozen (STGenM g) = STGen g
-  thawGen (STGen g) = fmap STGenM (newSTRef g)
-  freezeGen (STGenM gVar) = fmap STGen (readSTRef gVar)
+
+instance RandomGen g => MonadRandom (STGenM g s) (ST s) where
   uniformWord32R r = applySTGen (genWord32R r)
   {-# INLINE uniformWord32R #-}
   uniformWord64R r = applySTGen (genWord64R r)
@@ -387,7 +357,11 @@ applySTGen f (STGenM ref) = do
 --
 -- @since 1.2
 runSTGen :: RandomGen g => g -> (forall s . STGenM g s -> ST s a) -> (a, g)
-runSTGen g action = unSTGen <$> runST (runGenM (STGen g) action)
+runSTGen g action = runST $ do
+  stGen <- newSTRef g
+  res <- action $ STGenM stGen
+  g' <- readSTRef stGen
+  pure (res, g')
 
 -- | Runs a monadic generating action in the `ST` monad using a pure
 -- pseudo-random number generator. Returns only the resulting pseudo-random
@@ -543,10 +517,7 @@ runSTGen_ g action = fst $ runSTGen g action
 -- >>> :set -XUndecidableInstances
 --
 -- >>> :{
--- instance (s ~ PrimState m, PrimMonad m) => MonadRandom MWC.Gen s m where
---   type Frozen MWC.Gen = MWC.Seed
---   thawGen = MWC.restore
---   freezeGen = MWC.save
+-- instance (s ~ PrimState m, PrimMonad m) => MonadRandom (MWC.Gen s) m where
 --   uniformWord8 = MWC.uniform
 --   uniformWord16 = MWC.uniform
 --   uniformWord32 = MWC.uniform

--- a/src/System/Random/Monad.hs
+++ b/src/System/Random/Monad.hs
@@ -481,10 +481,7 @@ runSTGen_ g action = fst $ runSTGen g action
 -- Here is an example instance for the monadic pseudo-random number generator
 -- from the @mwc-random@ package:
 --
--- > instance (s ~ PrimState m, PrimMonad m) => MonadRandom MWC.Gen s m where
--- >   type Frozen MWC.Gen = MWC.Seed
--- >   thawGen = MWC.restore
--- >   freezeGen = MWC.save
+-- > instance (s ~ PrimState m, PrimMonad m) => MonadRandom (MWC.Gen s) m where
 -- >   uniformWord8 = MWC.uniform
 -- >   uniformWord16 = MWC.uniform
 -- >   uniformWord32 = MWC.uniform

--- a/src/System/Random/Stateful.hs
+++ b/src/System/Random/Stateful.hs
@@ -238,6 +238,9 @@ randomRM r = applyRandomGenM (randomR r)
 -- @since 1.2
 newtype AtomicGenM g = AtomicGenM { unAtomicGenM :: IORef g}
 
+-- | Creates a new 'AtomicGenM'.
+--
+-- @since 1.2
 newAtomicGenM :: MonadIO m => g -> m (AtomicGenM g)
 newAtomicGenM = fmap AtomicGenM . liftIO . newIORef
 
@@ -287,6 +290,9 @@ applyAtomicGen op (AtomicGenM gVar) =
 -- @since 1.2
 newtype IOGenM g = IOGenM { unIOGenM :: IORef g }
 
+-- | Creates a new 'IOGenM'.
+--
+-- @since 1.2
 newIOGenM :: MonadIO m => g -> m (IOGenM g)
 newIOGenM = fmap IOGenM . liftIO . newIORef
 
@@ -323,6 +329,9 @@ applyIOGen f (IOGenM ref) = liftIO $ do
 -- @since 1.2
 newtype STGenM g s = STGenM { unSTGenM :: STRef s g }
 
+-- | Creates a new 'STGenM'.
+--
+-- @since 1.2
 newSTGenM :: g -> ST s (STGenM g s)
 newSTGenM = fmap STGenM . newSTRef
 

--- a/stack-coveralls.yaml
+++ b/stack-coveralls.yaml
@@ -2,7 +2,5 @@ resolver: lts-14.27
 packages:
 - .
 extra-deps:
+- splitmix-0.1@sha256:d50c4d0801a35be7875a040470c09863342514930c82a7d25780a6c2efc4fda9,5249
 - rdtsc-1.3.0.1@sha256:0a6e8dc715ba82ad72c7e2b1c2f468999559bec059d50540719a80b00dcc4e66,1557
-flags:
-  splitmix:
-    random: false

--- a/stack-old.yaml
+++ b/stack-old.yaml
@@ -20,6 +20,7 @@ extra-deps:
 - splitmix-0.0.4@sha256:fb9bb8b54a2e76c8a021fe5c4c3798047e1f60e168379a1f80693047fe00ad0e,4813
 - doctest-0.16.2@sha256:2f96e9bbe9aee11b47453c82c24b3dc76cdbb8a2a7c984dfd60b4906d08adf68,6942
 - cabal-doctest-1.0.8@sha256:34dff6369d417df2699af4e15f06bc181d495eca9c51efde173deae2053c197c,1491
+- rdtsc-1.3.0.1@sha256:0a6e8dc715ba82ad72c7e2b1c2f468999559bec059d50540719a80b00dcc4e66,1557
 flags:
   splitmix:
     random: false

--- a/stack-old.yaml
+++ b/stack-old.yaml
@@ -17,10 +17,7 @@ extra-deps:
   # In addition, the doctests require 'SMGen' from the splitmix package to
   # implement 'Prim'. So far, this is only the case on lehin's fork, so we use
   # that.
-- splitmix-0.0.4@sha256:fb9bb8b54a2e76c8a021fe5c4c3798047e1f60e168379a1f80693047fe00ad0e,4813
+- splitmix-0.1@sha256:d50c4d0801a35be7875a040470c09863342514930c82a7d25780a6c2efc4fda9,5249
 - doctest-0.16.2@sha256:2f96e9bbe9aee11b47453c82c24b3dc76cdbb8a2a7c984dfd60b4906d08adf68,6942
 - cabal-doctest-1.0.8@sha256:34dff6369d417df2699af4e15f06bc181d495eca9c51efde173deae2053c197c,1491
 - rdtsc-1.3.0.1@sha256:0a6e8dc715ba82ad72c7e2b1c2f468999559bec059d50540719a80b00dcc4e66,1557
-flags:
-  splitmix:
-    random: false

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,5 @@
 resolver: lts-15.1
 packages:
 - .
-extra-deps: []
-flags:
-  splitmix:
-    random: false
+extra-deps:
+- splitmix-0.1@sha256:d50c4d0801a35be7875a040470c09863342514930c82a7d25780a6c2efc4fda9,5249

--- a/test/Spec/Range.hs
+++ b/test/Spec/Range.hs
@@ -6,7 +6,7 @@ module Spec.Range
   , uniformRangeWithinExcluded
   ) where
 
-import System.Random.Monad
+import System.Random.Stateful
 
 symmetric :: (RandomGen g, UniformRange a, Eq a) => g -> (a, a) -> Bool
 symmetric g (l, r) = fst (uniformR (l, r) g) == fst (uniformR (r, l) g)

--- a/test/Spec/Run.hs
+++ b/test/Spec/Run.hs
@@ -1,7 +1,7 @@
 module Spec.Run (runsEqual) where
 
 import Data.Word (Word64)
-import System.Random.Monad
+import System.Random.Stateful
 
 runsEqual :: RandomGen g => g -> IO Bool
 runsEqual g = do

--- a/test/Spec/Run.hs
+++ b/test/Spec/Run.hs
@@ -6,7 +6,9 @@ import System.Random.Monad
 runsEqual :: RandomGen g => g -> IO Bool
 runsEqual g = do
   let pureResult = runStateGen_ g uniformM :: Word64
-      stResult = runSTGen_ g uniformM
-  ioResult <- runGenM_ (IOGen g) uniformM
-  atomicResult <- runGenM_ (AtomicGen g) uniformM
+      stResult = runSTGen_ g uniformM :: Word64
+  ioGenM <- newIOGenM g
+  ioResult <- uniformM ioGenM
+  atomicGenM <- newAtomicGenM g
+  atomicResult <- uniformM atomicGenM
   return $ all (pureResult ==) [stResult, ioResult, atomicResult]


### PR DESCRIPTION
This PR covers some of them feedback we received from the community:

* extraneous state token parameter in `MonadRandom g s m` -  Removed the token and all functionality that relied on it: `thawGen` `freezeGen`, `withGenM` ...
* Suggestion to add FunDeps `MonadRandom g m | m -> g` - This is not a useful setup since it will require a generator to depend on a specific monad, which we are trying to avoid. Instead renamed the class to `StatefulGen`, to emphasize that it is the generator that is important, not the monad.
* New version of splitmix-0.1 was released that does not depend on `random`, setting it as a lower bound.


Other adjustments:
* Relax dependencies on non-library components, since they can't be stricter than the library itself.
* Relax warnings from `-Weverything` to `-Wall` to avoid useless compilation warnings.
* Fix CI, so it doesn't fail for PR that don't have coveralls token available
