### PR TITLE
Improve naming and argument consistency:

### DIFF
--- a/src/System/Random.hs
+++ b/src/System/Random.hs
@@ -183,7 +183,7 @@ uniformR r g = runStateGen g (uniformRM r)
 --
 -- @since 1.2.0
 genByteString :: RandomGen g => Int -> g -> (ByteString, g)
-genByteString n g = runStateGenST g (uniformByteString n)
+genByteString n g = runStateGenST g (uniformByteStringM n)
 {-# INLINE genByteString #-}
 
 -- | The class of types for which uniformly distributed values can be

--- a/src/System/Random/Internal.hs
+++ b/src/System/Random/Internal.hs
@@ -53,7 +53,7 @@ module System.Random.Internal
   -- * Pseudo-random values of various types
   , Uniform(..)
   , UniformRange(..)
-  , uniformByteString
+  , uniformByteStringM
   , uniformDouble01M
   , uniformDoublePositive01M
   , uniformFloat01M
@@ -342,9 +342,9 @@ genShortByteStringST n action =
 -- | Generates a pseudo-random 'ByteString' of the specified size.
 --
 -- @since 1.2.0
-{-# INLINE uniformByteString #-}
-uniformByteString :: StatefulGen g m => Int -> g -> m ByteString
-uniformByteString n g = do
+{-# INLINE uniformByteStringM #-}
+uniformByteStringM :: StatefulGen g m => Int -> g -> m ByteString
+uniformByteStringM n g = do
   ba <- uniformShortByteString n g
   pure $
 #if __GLASGOW_HASKELL__ < 802

--- a/src/System/Random/Stateful.hs
+++ b/src/System/Random/Stateful.hs
@@ -75,7 +75,7 @@ module System.Random.Stateful
   -- * Generators for sequences of pseudo-random bytes
   , genShortByteStringIO
   , genShortByteStringST
-  , uniformByteString
+  , uniformByteStringM
   , uniformDouble01M
   , uniformDoublePositive01M
   , uniformFloat01M
@@ -229,7 +229,7 @@ instance RandomGen r => RandomGenM (STGenM r s) r (ST s) where
 -- ====__Examples__
 --
 -- >>> import Data.Int (Int8)
--- >>> withMutableGen (IOGen (mkStdGen 217)) (`uniformListM` 5) :: IO ([Int8], IOGen StdGen)
+-- >>> withMutableGen (IOGen (mkStdGen 217)) (uniformListM 5) :: IO ([Int8], IOGen StdGen)
 -- ([-74,37,-50,-2,3],IOGen {unIOGen = StdGen {unStdGen = SMGen 4273268533320920145 15251669095119325999}})
 --
 -- @since 1.2.0
@@ -261,12 +261,12 @@ withMutableGen_ fg action = fst <$> withMutableGen fg action
 -- >>> import System.Random.Stateful
 -- >>> let pureGen = mkStdGen 137
 -- >>> g <- newIOGenM pureGen
--- >>> uniformListM g 10 :: IO [Bool]
+-- >>> uniformListM 10 g :: IO [Bool]
 -- [True,True,True,True,False,True,True,False,False,False]
 --
 -- @since 1.2.0
-uniformListM :: (StatefulGen g m, Uniform a) => g -> Int -> m [a]
-uniformListM gen n = replicateM n (uniformM gen)
+uniformListM :: (StatefulGen g m, Uniform a) => Int -> g -> m [a]
+uniformListM n gen = replicateM n (uniformM gen)
 
 -- | Generates a pseudo-random value using monadic interface and `Random` instance.
 --
@@ -370,7 +370,7 @@ applyAtomicGen op (AtomicGenM gVar) =
 --
 -- >>> import UnliftIO.Temporary (withSystemTempFile)
 -- >>> import Data.ByteString (hPutStr)
--- >>> let ioGen g = withSystemTempFile "foo.bin" $ \_ h -> uniformRM (0, 100) g >>= flip uniformByteString g >>= hPutStr h
+-- >>> let ioGen g = withSystemTempFile "foo.bin" $ \_ h -> uniformRM (0, 100) g >>= flip uniformByteStringM g >>= hPutStr h
 --
 -- and then run it:
 --


### PR DESCRIPTION
* Rename `uniformByteString` -> `uniformByteStringM`
* Flip arguments of `uniformListM` in order to keep it consistent
  with `uniformByteStringM` and `uniformRM`