### PR TITLE
Add NFData 

### DIFF
--- a/src/System/Random/Internal.hs
+++ b/src/System/Random/Internal.hs
@@ -65,7 +65,7 @@ module System.Random.Internal
   ) where
 
 import Control.Arrow
-import Control.DeepSeq (NFData)
+import Control.DeepSeq (NFData(..))
 import Control.Monad.IO.Class
 import Control.Monad.ST
 import Control.Monad.ST.Unsafe
@@ -372,6 +372,9 @@ pinnedByteArrayToForeignPtr ba# =
 --
 -- @since 1.2.0
 data StateGenM g = StateGenM
+
+instance NFData (StateGenM g) where
+  rnf StateGenM = ()
 
 -- | Wrapper for pure state gen, which acts as an immutable seed for the corresponding
 -- stateful generator `StateGenM`

--- a/src/System/Random/Stateful.hs
+++ b/src/System/Random/Stateful.hs
@@ -304,8 +304,13 @@ randomRM r = applyRandomGenM (randomR r)
 --     of its atomic operations.
 --
 -- @since 1.2.0
-newtype AtomicGenM g = AtomicGenM { unAtomicGenM :: IORef g}
 
+newtype AtomicGenM g =
+  AtomicGenM
+    { unAtomicGenM :: IORef g
+    }
+  deriving ( NFData -- ^ Only strict in the reference
+           )
 
 -- | Frozen version of mutable `AtomicGenM` generator
 --
@@ -377,7 +382,12 @@ applyAtomicGen op (AtomicGenM gVar) =
 -- >>> newIOGenM (mkStdGen 1729) >>= ioGen
 --
 -- @since 1.2.0
-newtype IOGenM g = IOGenM { unIOGenM :: IORef g }
+newtype IOGenM g =
+  IOGenM
+    { unIOGenM :: IORef g
+    }
+  deriving ( NFData -- ^ Only strict in the reference
+           )
 
 -- | Frozen version of mutable `IOGenM` generator
 --
@@ -438,7 +448,12 @@ applyIOGen f (IOGenM ref) = liftIO $ do
 -- *   'STGenM' is slower than 'StateGenM' due to the extra pointer indirection.
 --
 -- @since 1.2.0
-newtype STGenM g s = STGenM { unSTGenM :: STRef s g }
+newtype STGenM g s =
+  STGenM
+    { unSTGenM :: STRef s g
+    }
+  deriving ( NFData -- ^ Only strict in the reference
+           )
 
 -- | Frozen version of mutable `STGenM` generator
 --


### PR DESCRIPTION
Add NFData instances for `STGenM`, `IOGenM`, `AtomicGenM` and `StateGenM`

IORef and STRef have NFData instances. There is no reason not to derive them for mutable generators as well. Very useful for benchmarks and such.